### PR TITLE
feat(skills): add neostandard + ESLint 9 linting skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Skills for AI-assisted development.
 |-------|-------------|
 | `documentation` | Technical writer specializing in the Diátaxis documentation framework |
 | `fastify` | Comprehensive best practices for Fastify development |
+| `linting-neostandard-eslint9` | Linting workflows with neostandard and ESLint v9 flat config |
 | `node` | Best practices for Node.js development |
 | `nodejs-core` | Deep Node.js internals expertise including C++ addons, V8, libuv, and build systems |
 | `oauth` | OAuth 2.0/2.1 specification expert with deep RFC knowledge and Fastify integration patterns |

--- a/skills/linting-neostandard-eslint9/SKILL.md
+++ b/skills/linting-neostandard-eslint9/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: linting-neostandard-eslint9
+description: Linting workflows with neostandard and ESLint v9 flat config
+metadata:
+  tags: linting, neostandard, eslint, eslint9, flat-config, javascript, typescript
+---
+
+## When to use
+
+Use this skill when you need to:
+- Set up linting in a JavaScript or TypeScript project
+- Use `neostandard` as a Standard-like ESLint v9 flat-config baseline
+- Configure `eslint@9` with the flat config system (`eslint.config.js`/`eslint.config.mjs`)
+- Migrate from `standard` to `neostandard` or ESLint v9
+- Migrate from legacy `.eslintrc*` configuration to ESLint v9
+- Run linting consistently in CI and local development
+
+## How to use
+
+Read individual rule files for implementation details and examples:
+
+- [rules/neostandard.md](rules/neostandard.md) - Install, configure, and extend neostandard with ESLint
+- [rules/eslint-v9-flat-config.md](rules/eslint-v9-flat-config.md) - Build ESLint v9 flat config for JS/TS projects
+- [rules/migration-from-standard.md](rules/migration-from-standard.md) - Migrate from `standard` to `neostandard` or ESLint v9
+- [rules/migration-from-legacy-eslint.md](rules/migration-from-legacy-eslint.md) - Migrate from `.eslintrc*` to flat config safely
+- [rules/ci-and-editor-integration.md](rules/ci-and-editor-integration.md) - CI scripts, pre-commit, and editor setup
+
+## Core principles
+
+- Prefer reproducible linting with pinned major versions
+- Keep config minimal and explicit
+- Use flat config for ESLint v9 projects
+- Treat lint failures as quality gates in CI
+- Enable auto-fix for local workflows, but validate with non-fix CI runs

--- a/skills/linting-neostandard-eslint9/rules/ci-and-editor-integration.md
+++ b/skills/linting-neostandard-eslint9/rules/ci-and-editor-integration.md
@@ -1,0 +1,50 @@
+---
+name: ci-and-editor-integration
+description: Integrate neostandard and ESLint v9 with CI pipelines, pre-commit hooks, and editors
+metadata:
+  tags: ci, linting, neostandard, eslint, pre-commit, vscode
+---
+
+## CI guidance
+
+- Run lint in CI as a required step:
+
+```bash
+npm run lint
+```
+
+- Do not use auto-fix in CI.
+- Keep CI Node.js version aligned with local development and project engines.
+
+## Pre-commit hook pattern
+
+Use `lint-staged` (or equivalent) to lint only changed files before commit.
+
+```json
+{
+  "lint-staged": {
+    "*.{js,mjs,cjs,ts,mts,cts}": [
+      "eslint --fix"
+    ]
+  }
+}
+```
+
+When using `neostandard`, keep pre-commit execution on `eslint --fix` because ESLint is the actual runner.
+
+## VS Code integration
+
+- Install ESLint extension
+- Enable flat config support if required by extension version
+- Use `editor.codeActionsOnSave` for explicit, predictable auto-fixes
+
+Example workspace settings:
+
+```json
+{
+  "editor.codeActionsOnSave": {
+    "source.fixAll.eslint": "explicit"
+  },
+  "eslint.validate": ["javascript", "typescript"]
+}
+```

--- a/skills/linting-neostandard-eslint9/rules/eslint-v9-flat-config.md
+++ b/skills/linting-neostandard-eslint9/rules/eslint-v9-flat-config.md
@@ -1,0 +1,77 @@
+---
+name: eslint-v9-flat-config
+description: Configure ESLint 9 flat config, with neostandard as the preferred baseline
+metadata:
+  tags: eslint, eslint9, flat-config, neostandard, javascript, typescript
+---
+
+ESLint v9 uses flat config by default. Prefer `eslint.config.js` or `eslint.config.mjs` over legacy `.eslintrc*` files.
+
+## Preferred setup in this skill: neostandard baseline
+
+Install:
+
+```bash
+npm install --save-dev eslint neostandard
+```
+
+Create config (ESM helper):
+
+```bash
+npx neostandard --esm > eslint.config.js
+```
+
+Run lint:
+
+```bash
+npx eslint .
+```
+
+## Manual flat config (when not using neostandard)
+
+Install (example):
+
+```bash
+npm install --save-dev eslint @eslint/js typescript-eslint
+```
+
+Basic `eslint.config.mjs` (JS + TS):
+
+```js
+import js from '@eslint/js'
+import tseslint from 'typescript-eslint'
+
+export default [
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.{js,mjs,cjs,ts,mts,cts}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module'
+    },
+    rules: {
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }]
+    }
+  }
+]
+```
+
+## Package scripts
+
+```json
+{
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  }
+}
+```
+
+## Good practices
+
+- Use a single root flat config unless package-level variance is required
+- Keep TypeScript-aware rules scoped to TS files
+- Avoid duplicate JS/TS rules; disable base rule when TS extension rule is used
+- Keep CI on non-fix lint runs; reserve `--fix` for local workflows

--- a/skills/linting-neostandard-eslint9/rules/migration-from-legacy-eslint.md
+++ b/skills/linting-neostandard-eslint9/rules/migration-from-legacy-eslint.md
@@ -1,0 +1,28 @@
+---
+name: migration-from-legacy-eslint
+description: Safe migration plan from legacy ESLint rc config to ESLint v9 flat config
+metadata:
+  tags: eslint, eslint9, migration, flat-config
+---
+
+Use this checklist to migrate with low risk.
+
+## Migration checklist
+
+1. Upgrade ESLint major version:
+   ```bash
+   npm install --save-dev eslint@^9
+   ```
+2. Create `eslint.config.js` or `eslint.config.mjs`
+3. Translate legacy `extends`, `plugins`, and `overrides` into flat-config entries
+4. Remove `.eslintrc*` and deprecated ignore files once parity is verified
+5. Run lint and compare issue count before/after migration
+6. Fix rule parity gaps explicitly in config
+7. Update CI scripts to call `eslint .`
+
+## Pitfalls to avoid
+
+- Mixing legacy and flat config in the same project
+- Forgetting to disable base rules when TS variants are enabled
+- Assuming plugin presets are flat-config compatible without checking docs
+- Migrating config and rule semantics in a single large change without validation

--- a/skills/linting-neostandard-eslint9/rules/migration-from-standard.md
+++ b/skills/linting-neostandard-eslint9/rules/migration-from-standard.md
@@ -1,0 +1,70 @@
+---
+name: migration-from-standard
+description: Accurate migration path from standard to neostandard on ESLint v9
+metadata:
+  tags: standard, neostandard, eslint, eslint9, migration, flat-config
+---
+
+Use this when a project currently runs `standard` and you want modern ESLint v9 + flat config while keeping a Standard-like baseline.
+
+## Canonical migration flow
+
+1. Install dependencies:
+
+```bash
+npm install --save-dev neostandard eslint
+```
+
+2. (Optional preflight) verify helper command works:
+
+```bash
+npx neostandard --help
+```
+
+3. Generate migrated config from existing `package.json` `"standard"` settings:
+
+```bash
+npx neostandard --migrate > eslint.config.js
+```
+
+4. Replace lint scripts/CI commands from `standard` to `eslint`:
+
+```json
+{
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  }
+}
+```
+
+5. Cleanup old setup:
+
+```bash
+npm uninstall standard
+```
+
+Then remove obsolete top-level `"standard"` config and editor integrations specific to `standard` (for example `vscode-standard`).
+
+## Semicolon and TypeScript variants
+
+- semistandard-like migration:
+
+```bash
+npx neostandard --semi --migrate > eslint.config.js
+```
+
+- TypeScript support in resulting config: set `ts: true` (or regenerate/configure accordingly).
+
+## Behavioral differences to expect
+
+- neostandard is built for ESLint 9 flat config (no `standard-engine` wrapper)
+- rule implementation uses modern flat-config/plugin model
+- some rules differ from legacy standard/`eslint-config-standard` behavior
+- on neostandard v1+, import rules from `eslint-plugin-import-x` are not bundled by default
+
+If you relied heavily on import linting in your old setup, either:
+- add `eslint-plugin-import-x` explicitly, or
+- rely on `tsc --noEmit` (recommended for TypeScript-heavy projects)
+
+Run lint and fix incrementally after migration; keep tooling migration separate from rule-tuning commits.

--- a/skills/linting-neostandard-eslint9/rules/neostandard.md
+++ b/skills/linting-neostandard-eslint9/rules/neostandard.md
@@ -1,0 +1,86 @@
+---
+name: neostandard
+description: How neostandard actually works with ESLint v9 flat config
+metadata:
+  tags: neostandard, eslint, eslint9, flat-config, standardjs, typescript
+---
+
+`neostandard` is a **shared ESLint flat config** and config generator, not a standalone replacement linter command.
+
+## Key model
+
+- You install **both** `neostandard` and `eslint`
+- You generate or author `eslint.config.js` / `eslint.config.mjs`
+- You run linting via `eslint` (`eslint .`, `eslint . --fix`)
+
+## Install
+
+```bash
+npm install --save-dev neostandard eslint
+```
+
+## Create config
+
+Generate ESM config:
+
+```bash
+npx neostandard --esm > eslint.config.js
+```
+
+Generate CommonJS config:
+
+```bash
+npx neostandard > eslint.config.js
+```
+
+Or author manually (ESM):
+
+```js
+import neostandard from 'neostandard'
+
+export default neostandard({
+  ts: true
+})
+```
+
+## Run lint
+
+```json
+{
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix"
+  }
+}
+```
+
+## Common options
+
+- `ts: true` — lint `*.ts` and `*.d.ts`
+- `semi: true` — semicolon mode (semistandard-style)
+- `noStyle: true` — disable style rules (useful with Prettier/dprint)
+- `noJsx: true` — disable JSX rules
+- `ignores`, `files`, `filesTs`, `env`, `globals`
+
+## Version caveat (v1+)
+
+As of neostandard v1+, `eslint-plugin-import-x` is no longer bundled.
+
+- If you need deep import/export lint rules, add `eslint-plugin-import-x` explicitly
+- For many TypeScript projects, prefer `tsc --noEmit` for module/import correctness checks
+
+## Useful export
+
+Use `.gitignore` patterns as ESLint ignores:
+
+```js
+import neostandard, { resolveIgnoresFromGitignore } from 'neostandard'
+
+export default neostandard({
+  ignores: resolveIgnoresFromGitignore()
+})
+```
+
+## Important migration note
+
+For projects moving from `standard`, keep `neostandard` as the config source but run lint through `eslint`.


### PR DESCRIPTION
## Summary
- add a new `linting-neostandard-eslint9` skill package
- add focused rules for neostandard usage, ESLint v9 flat config, migrations, and CI/editor integration
- add migration guidance from `standard` using `npx neostandard --migrate`
- correct execution model: use `eslint` as the lint runner, with neostandard as config baseline
- document neostandard v1+ caveat around import checking (`eslint-plugin-import-x` not bundled)
- list the new skill in `README.md`

## Notes
- Documentation-only change
- I did not run `npm run typecheck` / `npm test` because local toolchain deps are not installed (`node_modules/.bin/tsc` missing)
