### PR TITLE
docs(octocat): Add PR body formatting guide

### DIFF
--- a/skills/octocat/SKILL.md
+++ b/skills/octocat/SKILL.md
@@ -56,6 +56,54 @@ GitHub operations via gh CLI:
 - Configure repository settings
 - Automate workflows and notifications
 
+## PR Body Formatting (Important)
+
+When creating PRs with `gh pr create`, the `--body` flag has escaping issues with newlines. The `\n` sequences get escaped as literal characters instead of actual newlines.
+
+### The Problem
+❌ This produces literal `\n` in the PR body:
+```bash
+gh pr create --body "Line 1\nLine 2\nLine 3"
+```
+
+### Solutions
+
+**Option 1: Use `--body-file` (Recommended)**
+```bash
+cat > /tmp/pr-body.md << 'EOF'
+Line 1
+
+Line 2
+Line 3
+EOF
+gh pr create --body-file /tmp/pr-body.md
+```
+
+**Option 2: Use `printf` with proper escaping**
+```bash
+gh pr create --body "$(printf 'Line 1\n\nLine 2\nLine 3')"
+```
+
+**Option 3: Use `echo -e` (works in bash)**
+```bash
+gh pr create --body "$(echo -e "Line 1\n\nLine 2\nLine 3")"
+```
+
+**Option 4: Multi-line with heredoc in shell**
+```bash
+body=$(cat << 'EOF'
+Line 1
+
+Line 2
+Line 3
+EOF
+)
+gh pr create --body "$body"
+```
+
+### Best Practice
+For complex PR descriptions with formatting, always use `--body-file` with a temporary file. It's cleaner, more reliable, and easier to debug.
+
 Pre-commit hook philosophy:
 - Fix linting errors directly when possible
 - Delegate TypeScript issues to the typescript-magician


### PR DESCRIPTION
Document proper techniques for formatting PR bodies when using gh pr create.\n\n## Problem\nThe --body flag has escaping issues with newlines - the \n sequences get escaped as literal characters instead of actual newlines.\n\n## Solutions Documented\n1. Use --body-file (recommended)\n2. Use printf with proper escaping\n3. Use echo -e\n4. Use heredoc in shell\n\nThis helps future agents avoid the formatting issues I encountered.