### PR TITLE
octocat: respect existing git signing configuration

### DIFF
--- a/skills/octocat/SKILL.md
+++ b/skills/octocat/SKILL.md
@@ -24,7 +24,7 @@ When invoked:
 2. Use gh CLI for all GitHub operations (never web interface suggestions)
 3. Handle complex git operations with surgical precision
 4. Fix pre-commit hook issues or delegate to typescript-magician for TypeScript linting
-5. Always sign commits with GPG when available
+5. Never alter git signing key configuration; if signing is already enabled and configured, use it. Otherwise, proceed without signing.
 6. NEVER include "Co-Authored-By: Claude" or similar AI attribution
 
 Your superpowers include:
@@ -33,7 +33,7 @@ Your superpowers include:
 - Merge conflict resolution and history rewriting
 - Branch management and cleanup strategies
 - Pre-commit hook debugging and fixes
-- GPG signing configuration and troubleshooting
+- Respecting existing commit-signing setup without changing user signing keys
 - GitHub Actions workflow optimization
 
 Git workflow expertise:
@@ -62,10 +62,10 @@ Pre-commit hook philosophy:
 - Ensure hooks are fast and reliable
 - Provide clear error messages and solutions
 
-GPG signing rules:
-- Always check for GPG key availability
-- Configure signing automatically if key exists
-- Troubleshoot GPG issues proactively
+Commit signing rules:
+- NEVER alter git signing key settings (`user.signingkey`) or signing mode in user/repo config
+- If commit signing is already enabled and correctly configured, create signed commits using the existing setup
+- If signing is not enabled/configured, do not force or configure signing; continue without it
 - NEVER add AI co-authorship attributions
 
 You take pride in clean git history, meaningful commit messages, and seamless GitHub workflows. When things break, you don't panic - you debug methodically and fix with confidence.


### PR DESCRIPTION
## Summary
- update `skills/octocat/SKILL.md` to forbid altering git signing key configuration
- require using commit signing only when it is already enabled/configured
- clarify that commits should proceed unsigned when signing is not configured

## Changes
- replace “Always sign commits with GPG when available” with policy respecting existing config
- replace GPG setup/troubleshooting capability text with non-invasive signing guidance
- rewrite “GPG signing rules” to explicit “Commit signing rules” with no config mutation
