### PR TITLE
feat(skills): add snipgrapher skill for snippet image generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Current top-level skills include:
 - `nodejs-core`
 - `oauth`
 - `octocat`
+- `snipgrapher`
 - `typescript-magician`
 
 ### 2) Minimal TypeScript package surface (`src/`)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,8 @@ Run from repository root.
 ## Editing rules for this repo
 
 1. Treat `skills/*/SKILL.md` as an index contract.
-   - If you add/rename/remove any `rules/*.md`, update the corresponding links in `SKILL.md`.
+   - Every `rules/*.md` file must be explicitly mentioned and linked from that skill’s main `SKILL.md`.
+   - If you add/rename/remove any `rules/*.md`, update the corresponding links in `SKILL.md` in the same change.
 
 2. Preserve skill metadata/frontmatter format.
    - Skill and rule docs use YAML frontmatter (`name`, `description`, `metadata.tags`).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Skills for AI-assisted development.
 | `nodejs-core` | Deep Node.js internals expertise including C++ addons, V8, libuv, and build systems |
 | `oauth` | OAuth 2.0/2.1 specification expert with deep RFC knowledge and Fastify integration patterns |
 | `octocat` | Git and GitHub wizard using gh CLI for all git operations and GitHub interactions |
+| `snipgrapher` | Configure and use snipgrapher to generate polished code snippet images |
 | `typescript-magician` | TypeScript wizard specializing in advanced type systems, complex generics, and eliminating any types |
 
 ## Usage

--- a/skills/snipgrapher/SKILL.md
+++ b/skills/snipgrapher/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: snipgrapher
+description: Configure and use snipgrapher to generate polished code snippet images
+metadata:
+  tags: snipgrapher, snippets, images, svg, png, webp, cli
+---
+
+## When to use
+
+Use this skill when you need to:
+- Generate image snippets from source code
+- Configure reusable snippet rendering defaults
+- Batch-render snippet assets for docs, social posts, or changelogs
+- Use published `snipgrapher` from npm to generate snippet images
+
+## How to use
+
+Read these rule files in order:
+
+- [rules/setup-and-configuration.md](rules/setup-and-configuration.md) - Install, select executable, initialize config, and define profiles
+- [rules/rendering-workflows.md](rules/rendering-workflows.md) - Render single snippets, batch jobs, watch mode, and output practices
+
+## Core principles
+
+- **Configure first**: establish a project config before repeated renders
+- **Reproducible output**: prefer named profiles and explicit output paths
+- **Portable commands**: use command patterns that work with installed binaries and `npx`
+- **Automation-friendly**: rely on CLI flags/config/env precedence intentionally

--- a/skills/snipgrapher/rules/rendering-workflows.md
+++ b/skills/snipgrapher/rules/rendering-workflows.md
@@ -1,0 +1,77 @@
+---
+name: rendering-workflows
+description: Generate snippet images with render, batch, and watch flows
+metadata:
+  tags: snipgrapher, render, batch, watch, snippets
+---
+
+## Single-file rendering
+
+Basic SVG output:
+
+```bash
+snipgrapher render ./example.ts -o snippet.svg
+```
+
+Generate PNG or WebP:
+
+```bash
+snipgrapher render ./example.ts --format png -o snippet.png
+snipgrapher render ./example.ts --format webp -o snippet.webp
+```
+
+Styling overrides:
+
+```bash
+snipgrapher render ./example.ts --background-style gradient --window-controls --shadow
+snipgrapher render ./example.ts --watermark "snipgrapher" --language typescript
+```
+
+Profile-based rendering:
+
+```bash
+snipgrapher render ./example.ts --profile social -o snippet-social.svg
+```
+
+## Stdin and piping
+
+From stdin:
+
+```bash
+cat ./example.ts | snipgrapher render --stdin -o snippet.svg
+```
+
+Or rely on auto-stdin detection:
+
+```bash
+cat ./example.ts | snipgrapher render -o snippet.svg
+```
+
+When `--output` is omitted and stdout is redirected, image bytes are written to stdout.
+
+## Batch rendering
+
+Render many files with glob patterns:
+
+```bash
+snipgrapher batch "./snippets/**/*.ts" --out-dir rendered --concurrency 6
+snipgrapher batch "./snippets/**/*.ts" --json --manifest rendered/manifest.json
+```
+
+## Watch mode
+
+Regenerate on file change:
+
+```bash
+snipgrapher watch ./example.ts -o snippet.svg --profile social
+```
+
+## Assistant behavior guidelines
+
+When asked to generate snippet images:
+
+1. Ensure configuration exists (create/update `snipgrapher.config.*` first).
+2. Use explicit output paths and file extensions.
+3. Prefer named profiles for repeatability.
+4. Return the exact command(s) run and the output file paths created.
+5. If `snipgrapher` is unavailable, fall back to npm (`npx --yes snipgrapher ...`).

--- a/skills/snipgrapher/rules/setup-and-configuration.md
+++ b/skills/snipgrapher/rules/setup-and-configuration.md
@@ -1,0 +1,89 @@
+---
+name: setup-and-configuration
+description: Install and configure snipgrapher with stable defaults and profiles
+metadata:
+  tags: snipgrapher, setup, config, profiles, cli
+---
+
+## Goal
+
+Set up `snipgrapher` so snippet rendering is deterministic and easy to repeat.
+
+## 1) Pick an executable strategy
+
+Use one of these:
+
+1. Binary available in PATH: `snipgrapher`
+2. npm package without global install:
+
+```bash
+npx --yes snipgrapher doctor
+```
+
+## 2) Initialize configuration
+
+Create a baseline config in the current project:
+
+```bash
+snipgrapher init
+```
+
+Supported config filenames (first match wins):
+- `snipgrapher.config.json`
+- `snipgrapher.config.yaml`
+- `snipgrapher.config.yml`
+- `snipgrapher.config.toml`
+
+## 3) Define reusable defaults and profiles
+
+Use a config structure like:
+
+```json
+{
+  "theme": "nord",
+  "fontFamily": "Fira Code",
+  "fontSize": 14,
+  "padding": 32,
+  "lineNumbers": true,
+  "windowControls": true,
+  "shadow": true,
+  "backgroundStyle": "gradient",
+  "format": "svg",
+  "defaultProfile": "default",
+  "profiles": {
+    "default": {},
+    "social": {
+      "padding": 48,
+      "fontSize": 16,
+      "watermark": "@your-handle"
+    }
+  }
+}
+```
+
+## 4) Validate environment and config
+
+Run:
+
+```bash
+snipgrapher doctor
+snipgrapher themes list
+```
+
+Fix validation errors before rendering.
+
+## 5) Understand precedence for overrides
+
+Rendering values resolve as:
+
+**CLI flags > environment variables > config file > defaults**
+
+Useful env vars include:
+- `SNIPGRAPHER_PROFILE`
+- `SNIPGRAPHER_THEME`
+- `SNIPGRAPHER_FORMAT`
+- `SNIPGRAPHER_FONT_SIZE`
+- `SNIPGRAPHER_PADDING`
+- `SNIPGRAPHER_LINE_NUMBERS`
+
+Use env vars for CI-wide defaults, and CLI flags for one-off overrides.


### PR DESCRIPTION
## Summary
- add a new `snipgrapher` skill under `skills/snipgrapher/`
- add setup/configuration guidance for configuring snipgrapher before rendering
- add rendering workflow guidance for single-file, stdin, batch, and watch mode
- remove local checkout usage and standardize execution to `snipgrapher` (PATH) or `npx --yes snipgrapher`
- update top-level skill listings in `README.md` and `AGENTS.md`

## Testing
- not run (documentation-only changes)
