### PR TITLE
fix(skills): rewrite descriptions and align frontmatter names

### DIFF
--- a/skills/documentation/SKILL.md
+++ b/skills/documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation
-description: Technical writer specializing in the Diátaxis documentation framework
+description: Creates and reviews technical documentation following the Diátaxis framework (tutorials, how-to guides, reference, explanations). Use when writing, restructuring, or improving user-facing documentation.
 metadata:
   tags: documentation, technical-writing, tutorials, guides, reference, diataxis
 ---

--- a/skills/fastify/SKILL.md
+++ b/skills/fastify/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: fastify-best-practices
-description: Comprehensive best practices for Fastify development
+name: fastify
+description: Provides Fastify best practices for plugins, routes, schemas, hooks, testing, and deployment. Use when developing or reviewing Fastify applications.
 metadata:
   tags: fastify, nodejs, typescript, backend, api, server, http
 ---

--- a/skills/linting-neostandard-eslint9/SKILL.md
+++ b/skills/linting-neostandard-eslint9/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linting-neostandard-eslint9
-description: Linting workflows with neostandard and ESLint v9 flat config
+description: Configures linting with neostandard and ESLint v9 flat config. Use when setting up linting, migrating from standard or legacy eslintrc, or integrating lint checks in CI.
 metadata:
   tags: linting, neostandard, eslint, eslint9, flat-config, javascript, typescript
 ---

--- a/skills/node/SKILL.md
+++ b/skills/node/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: node-best-practices
-description: Best practices for Node.js development with TypeScript using type stripping
+name: node
+description: Provides Node.js best practices for TypeScript with type stripping, error handling, streams, testing, and performance. Use when writing or reviewing Node.js backend code.
 metadata:
   tags: node, nodejs, javascript, typescript, type-stripping, backend, server
 ---

--- a/skills/nodejs-core/SKILL.md
+++ b/skills/nodejs-core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nodejs-core
-description: Deep Node.js internals expertise including C++ addons, V8, libuv, and build systems
+description: Provides deep Node.js internals guidance for V8, libuv, C++ addons, native memory, and build systems. Use when debugging native code, profiling V8, or contributing to Node.js core.
 metadata:
   tags: nodejs, v8, libuv, cpp, native-addons, performance, debugging, internals
 ---

--- a/skills/oauth/SKILL.md
+++ b/skills/oauth/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: oauth
-description: OAuth 2.0/2.1 specification expert with deep RFC knowledge and Fastify integration patterns
+description: Provides OAuth 2.0/2.1 spec-compliant guidance with Fastify integration patterns. Use when implementing authorization flows, token validation, PKCE, or OAuth security best practices.
 metadata:
   tags: oauth, oauth2, security, authentication, authorization, jwt, fastify
 ---

--- a/skills/octocat/SKILL.md
+++ b/skills/octocat/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: octocat
-description: Git and GitHub wizard using gh CLI for all git operations and GitHub interactions
+description: Performs git operations and GitHub interactions using gh CLI. Use when creating PRs, resolving merge conflicts, managing branches, or fixing pre-commit hooks.
 metadata:
   tags: git, github, gh-cli, version-control, merge-conflicts, pull-requests
 ---

--- a/skills/snipgrapher/SKILL.md
+++ b/skills/snipgrapher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: snipgrapher
-description: Configure and use snipgrapher to generate polished code snippet images
+description: Generates polished code snippet images using snipgrapher CLI. Use when creating snippet images for docs, social posts, or changelogs.
 metadata:
   tags: snipgrapher, snippets, images, svg, png, webp, cli
 ---

--- a/skills/typescript-magician/SKILL.md
+++ b/skills/typescript-magician/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: typescript-magician
-description: TypeScript wizard specializing in advanced type systems, complex generics, and eliminating any types
+description: Resolves TypeScript type errors, eliminates any types, and crafts advanced generics and conditional types. Use when facing type challenges, strict typing needs, or complex inference issues.
 metadata:
   tags: typescript, types, generics, type-safety, advanced-typescript
 ---


### PR DESCRIPTION
## Summary

- Rewrite all 9 skill descriptions in third person with explicit "Use when..." triggers for better discovery
- Align frontmatter `name` with directory name (`node-best-practices` -> `node`, `fastify-best-practices` -> `fastify`)

## Motivation

Following [official skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#writing-effective-descriptions):

- **Descriptions should be in third person** -- the description is injected into the system prompt, and inconsistent point-of-view causes discovery problems
- **Include both what the skill does and when to use it** -- Claude uses description to choose the right skill from potentially 100+ available skills
- **`name` should match the directory** to avoid confusion in programmatic lookups

---

Thanks for the great collection of skills!
