### PR TITLE
fix(octocat): simplify PR body formatting to one recommended approach

### DIFF
--- a/skills/octocat/SKILL.md
+++ b/skills/octocat/SKILL.md
@@ -56,19 +56,10 @@ GitHub operations via gh CLI:
 - Configure repository settings
 - Automate workflows and notifications
 
-## PR Body Formatting (Important)
+## PR Body Formatting
 
-When creating PRs with `gh pr create`, the `--body` flag has escaping issues with newlines. The `\n` sequences get escaped as literal characters instead of actual newlines.
+Always use `--body-file` for multi-line PR bodies to avoid newline escaping issues:
 
-### The Problem
-❌ This produces literal `\n` in the PR body:
-```bash
-gh pr create --body "Line 1\nLine 2\nLine 3"
-```
-
-### Solutions
-
-**Option 1: Use `--body-file` (Recommended)**
 ```bash
 cat > /tmp/pr-body.md << 'EOF'
 Line 1
@@ -78,31 +69,6 @@ Line 3
 EOF
 gh pr create --body-file /tmp/pr-body.md
 ```
-
-**Option 2: Use `printf` with proper escaping**
-```bash
-gh pr create --body "$(printf 'Line 1\n\nLine 2\nLine 3')"
-```
-
-**Option 3: Use `echo -e` (works in bash)**
-```bash
-gh pr create --body "$(echo -e "Line 1\n\nLine 2\nLine 3")"
-```
-
-**Option 4: Multi-line with heredoc in shell**
-```bash
-body=$(cat << 'EOF'
-Line 1
-
-Line 2
-Line 3
-EOF
-)
-gh pr create --body "$body"
-```
-
-### Best Practice
-For complex PR descriptions with formatting, always use `--body-file` with a temporary file. It's cleaner, more reliable, and easier to debug.
 
 Pre-commit hook philosophy:
 - Fix linting errors directly when possible


### PR DESCRIPTION
## Summary

Simplify the "PR Body Formatting" section in octocat from 4 alternative solutions (~40 lines) to the single recommended approach (`--body-file`, ~10 lines).

## What changed

**Before:** A "Problem" section, then 4 separate solutions (--body-file, printf, echo -e, heredoc variable), then a "Best Practice" paragraph recommending option 1 anyway.

**After:** One directive sentence + one code example.

## Why

The [official skill authoring best practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices#avoid-offering-too-many-options) explicitly warn against the "too many options" anti-pattern:

> *Don't present multiple approaches unless necessary. Provide a default.*

The old section listed 4 ways to solve the same problem, then recommended option 1 anyway. This wastes context window tokens and creates unnecessary decision points for the agent. The `--body-file` approach is the most reliable and the only one needed.

The "(Important)" annotation was also removed from the heading -- AI agents determine importance from the content itself, not from heading annotations.

---

Thanks for the great collection of skills!
