### PR TITLE
Node:Performance Skill - Fix hashPassword function to remove uneeded async keyword

### DIFF
--- a/skills/node/rules/performance.md
+++ b/skills/node/rules/performance.md
@@ -18,7 +18,7 @@ function hashPasswordSync(password: string): string {
 }
 
 // GOOD - async operation
-async function hashPassword(password: string): Promise<string> {
+function hashPassword(password: string): Promise<string> {
   return new Promise((resolve, reject) => {
     crypto.pbkdf2(password, salt, 100000, 64, 'sha512', (err, key) => {
       if (err) reject(err);


### PR DESCRIPTION
The example is returning a `Promise` with no uses of `await`, causing the use of `async` to be an extra, unneeded promise wrapper.