### PR TITLE
feat: improve skill descriptions and content for better discoverability

### DIFF
--- a/skills/documentation/SKILL.md
+++ b/skills/documentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: documentation
-description: Technical writer specializing in the Diátaxis documentation framework
+description: "Creates, structures, and reviews technical documentation following the Diátaxis framework (tutorials, how-to guides, reference, and explanation pages). Use when a user needs to write or reorganize docs, structure a tutorial vs. a how-to guide, build reference docs or API documentation, create explanation pages, choose between Diátaxis documentation types, or improve existing documentation structure. Trigger terms include: documentation structure, Diátaxis, tutorials vs how-to guides, organize docs, user guide, reference docs, technical writing."
 metadata:
   tags: documentation, technical-writing, tutorials, guides, reference, diataxis
 ---
@@ -15,28 +15,95 @@ Use this skill when you need to create, review, or improve technical documentati
 
 ## Instructions
 
-You are an expert technical writer specializing in the Diátaxis documentation framework (formerly the Divio Documentation System). You understand that there are four distinct types of documentation - tutorials, how-to guides, reference material, and explanations - each serving different user needs and contexts.
+Organize documentation into four distinct types — tutorials, how-to guides, reference material, and explanations — each serving different user needs and contexts.
 
-When creating or reviewing documentation, you will:
+Always ask clarifying questions about the user's context, audience, and goals **before** creating documentation.
 
-1. **Identify the documentation type needed** based on user context:
-   - Tutorials: For beginners learning by doing (learning-oriented)
-   - How-to guides: For experienced users solving specific problems (problem-oriented)
-   - Reference: For users needing technical specifications (information-oriented)
-   - Explanations: For users seeking deeper understanding (understanding-oriented)
+---
 
-2. **Apply type-specific best practices**:
-   - **Tutorials**: Provide step-by-step instructions that work reliably, show immediate results, focus on concrete actions, minimize explanations, ensure repeatability
-   - **How-to guides**: Address specific "How do I...?" questions, assume basic knowledge, focus on achieving practical goals, allow some flexibility
-   - **Reference**: Provide accurate technical descriptions, maintain consistent structure, avoid instruction beyond basic usage, keep information current
-   - **Explanations**: Offer context and background, discuss alternatives, provide higher-level perspective, avoid instruction or technical reference
+### Step 1 — Identify the documentation type
 
-3. **Maintain clear separation** between documentation types while ensuring they work together as an integrated system
+Use the following decision checklist based on user signals:
 
-4. **Structure content appropriately** for the target audience's knowledge level and immediate goals
+| User signal | Documentation type |
+|---|---|
+| "I'm new to X and want to learn it" / "walk me through" | **Tutorial** |
+| "How do I…?" / "I need to accomplish X" | **How-to guide** |
+| "What are the parameters/options/syntax for X?" | **Reference** |
+| "Why does X work this way?" / "Help me understand X" | **Explanation** |
 
-5. **Write in clear, accessible language** that serves the user's needs in that moment
+Quick decision tree:
+- Is the user **learning by doing** for the first time? → Tutorial
+- Do they need to **solve a specific problem** they already understand? → How-to guide
+- Do they need **technical facts** to look up? → Reference
+- Do they want **conceptual background**? → Explanation
 
-6. **Test and validate** that tutorials work as written and that how-to guides solve the stated problems
+---
 
-You will always ask clarifying questions about the user's context, audience, and goals before creating documentation. You understand that good documentation isn't just well-written - it's the right type of documentation for the user's current needs and situation.
+### Step 2 — Apply type-specific patterns
+
+#### Tutorials (learning-oriented)
+- **Title pattern:** Start with a verb — *"Build your first X"*, *"Create a Y from scratch"*
+- Structure: Goal → Prerequisites → Numbered steps → Immediate verifiable result at each step → Final outcome
+- Minimise explanation; maximise doing
+- Every step must produce a visible, testable result
+- **Validation:** A beginner must be able to complete the tutorial without external help
+
+**Example intro:**
+> *"In this tutorial, you will build a simple REST API using Express. By the end, you will have a running server that responds to GET requests. No prior Express experience is needed."*
+
+---
+
+#### How-to guides (problem-oriented)
+- **Title pattern:** Frame as a task — *"How to configure X"*, *"How to deploy Y to Z"*
+- Structure: Goal statement → Assumptions/prerequisites → Numbered steps → Expected result
+- Assume baseline knowledge; skip conceptual explanations
+- Allow for variation; note alternatives where they exist
+- **Validation:** An experienced user can complete the task without confusion or backtracking
+
+**Example intro:**
+> *"This guide shows how to add JWT authentication to an existing Express app. It assumes you have a working Express server and basic familiarity with middleware."*
+
+---
+
+#### Reference (information-oriented)
+- **Title pattern:** Name the thing — *"Configuration options"*, *"API endpoints"*, *"CLI flags"*
+- Structure: Consistent repeatable format per entry (name → type → default → description → example)
+- State facts; avoid instruction beyond minimal usage examples
+- Keep current; version-stamp if needed
+- **Validation:** A user can look up a specific fact in under 30 seconds without reading surrounding content
+
+**Example entry:**
+> **`timeout`** *(integer, default: `5000`)*
+> Maximum time in milliseconds to wait for a response before the request fails.
+> *Example:* `{ timeout: 3000 }`
+
+---
+
+#### Explanations (understanding-oriented)
+- **Title pattern:** Frame as a concept — *"How X works"*, *"Understanding Y"*, *"Why Z is designed this way"*
+- Structure: Context → Core concept → Alternatives/trade-offs → Higher-level perspective
+- Avoid step-by-step instruction or technical specification
+- **Validation:** After reading, the user can explain the concept in their own words and understands the rationale behind design decisions
+
+**Example intro:**
+> *"Authentication and authorisation are often confused. This page explains the distinction, why both matter, and how common patterns (sessions, tokens, OAuth) approach each concern differently."*
+
+---
+
+### Step 3 — Maintain separation and integration
+
+- Keep each document a single type — don't mix tutorial steps with reference tables or conceptual digressions
+- Cross-link between types: a tutorial can link to the relevant reference page; a how-to guide can link to an explanation for background
+- Use consistent headings and terminology across all types so users can navigate the full documentation system
+
+---
+
+### Step 4 — Validate before delivering
+
+| Type | Validation check |
+|---|---|
+| Tutorial | Can a beginner complete it end-to-end without external help? |
+| How-to guide | Does it solve the stated problem for an experienced user? |
+| Reference | Can the user find a specific fact in under 30 seconds? |
+| Explanation | Does the user understand the *why*, not just the *what*? |

--- a/skills/fastify/SKILL.md
+++ b/skills/fastify/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fastify-best-practices
-description: Comprehensive best practices for Fastify development
+description: "Guides development of Fastify Node.js backend servers and REST APIs using TypeScript or JavaScript. Use when building, configuring, or debugging a Fastify application — including defining routes, implementing plugins, setting up JSON Schema validation, handling errors, optimising performance, managing authentication, configuring CORS and security headers, integrating databases, working with WebSockets, and deploying to production. Covers the full Fastify request lifecycle (hooks, serialization, logging with Pino) and TypeScript integration via strip types. Trigger terms: Fastify, Node.js server, REST API, API routes, backend framework, fastify.config, server.ts, app.ts."
 metadata:
   tags: fastify, nodejs, typescript, backend, api, server, http
 ---
@@ -14,6 +14,33 @@ Use this skill when you need to:
 - Use TypeScript with Fastify (strip types)
 - Implement testing with Fastify's inject method
 - Configure validation, serialization, and error handling
+
+## Quick Start
+
+A minimal, runnable Fastify server to get started immediately:
+
+```ts
+import Fastify from 'fastify'
+
+const app = Fastify({ logger: true })
+
+app.get('/health', async (request, reply) => {
+  return { status: 'ok' }
+})
+
+const start = async () => {
+  await app.listen({ port: 3000, host: '0.0.0.0' })
+}
+start()
+```
+
+## Recommended Reading Order for Common Scenarios
+
+- **New to Fastify?** Start with `plugins.md` → `routes.md` → `schemas.md`
+- **Adding authentication:** `plugins.md` → `hooks.md` → `authentication.md`
+- **Improving performance:** `schemas.md` → `serialization.md` → `performance.md`
+- **Setting up testing:** `routes.md` → `testing.md`
+- **Going to production:** `logging.md` → `configuration.md` → `deployment.md`
 
 ## How to use
 

--- a/skills/init/SKILL.md
+++ b/skills/init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: init
-description: Create or refine a minimal, high-signal AGENTS.md with only non-discoverable repo guidance
+description: Creates, updates, or optimizes an AGENTS.md file for a repository with minimal, high-signal instructions covering non-discoverable coding conventions, tooling quirks, workflow preferences, and project-specific rules that agents cannot infer from reading the codebase. Use when setting up agent instructions or Claude configuration for a new repository, when an existing AGENTS.md is too long, generic, or stale, when agents repeatedly make avoidable mistakes, or when repository workflows have changed and the agent configuration needs pruning. Applies a discoverability filter—omitting anything Claude can learn from README, code, config, or directory structure—and a quality gate to verify each line remains accurate and operationally significant.
 metadata:
   tags: initialization, agents, context-engineering, agents-md, maintenance
 ---

--- a/skills/linting-neostandard-eslint9/SKILL.md
+++ b/skills/linting-neostandard-eslint9/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: linting-neostandard-eslint9
-description: Linting workflows with neostandard and ESLint v9 flat config
+description: Configures ESLint v9 flat config and neostandard for JavaScript and TypeScript projects, including migrating from legacy `.eslintrc*` files or the `standard` package. Use when you need to set up or fix linting with `eslint.config.js` or `eslint.config.mjs`, troubleshoot lint errors, configure neostandard rules, migrate from `.eslintrc` to flat config, or integrate linting into CI pipelines and pre-commit hooks.
 metadata:
   tags: linting, neostandard, eslint, eslint9, flat-config, javascript, typescript
 ---
@@ -14,6 +14,36 @@ Use this skill when you need to:
 - Migrate from `standard` to `neostandard` or ESLint v9
 - Migrate from legacy `.eslintrc*` configuration to ESLint v9
 - Run linting consistently in CI and local development
+
+## Quick start: basic neostandard setup
+
+Install dependencies and create a minimal `eslint.config.js`:
+
+```bash
+npm install --save-dev eslint@9 neostandard
+```
+
+```js
+// eslint.config.js
+import neostandard from 'neostandard'
+
+export default neostandard()
+```
+
+Verify the config works:
+
+```bash
+npx eslint .
+```
+
+## Common setup workflow (new project)
+
+1. Install `eslint@9` and `neostandard` (see Quick start above)
+2. Create `eslint.config.js` with `neostandard()` as the base
+3. Add any project-specific rule overrides on top
+4. Run `npx eslint .` to confirm no config errors
+5. Add a lint script to `package.json`: `"lint": "eslint ."`
+6. Integrate into CI with a non-fix run; use `--fix` only in local workflows
 
 ## How to use
 

--- a/skills/node/SKILL.md
+++ b/skills/node/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: node-best-practices
-description: Best practices for Node.js development with TypeScript using type stripping
+description: Provides domain-specific best practices for Node.js development with TypeScript, covering type stripping, async patterns, error handling, streams, modules, testing, performance, caching, logging, and more. Use when setting up Node.js projects with native TypeScript support, configuring type stripping (--experimental-strip-types), writing Node 22+ TypeScript without a build step, or when the user mentions 'native TypeScript in Node', 'strip types', 'Node 22 TypeScript', '.ts files without compilation', 'ts-node alternative', or needs guidance on error handling, graceful shutdown, flaky tests, profiling, or environment configuration in Node.js. Helps configure tsconfig.json for type stripping, set up package.json scripts, handle module resolution and import extensions, and apply robust patterns across the full Node.js stack.
 metadata:
   tags: node, nodejs, javascript, typescript, type-stripping, backend, server
 ---
@@ -19,7 +19,34 @@ Key requirements for type stripping compatibility:
 - Avoid namespaces and parameter properties
 - Use `.ts` extensions in imports
 
+**Minimal example** — a valid type-stripped TypeScript file:
+
+```ts
+// greet.ts
+import type { IncomingMessage } from 'node:http';
+
+const greet = (name: string): string => `Hello, ${name}!`;
+console.log(greet('world'));
+```
+
+Run directly with:
+```bash
+node greet.ts
+```
+
 See [rules/typescript.md](rules/typescript.md) for complete configuration and examples.
+
+## Common Workflows
+
+For multi-step processes, follow these high-level sequences before consulting the relevant rule file:
+
+**Graceful shutdown**: Register signal handlers (SIGTERM/SIGINT) → stop accepting new work → drain in-flight requests → close external connections (DB, cache) → exit with appropriate code. See [rules/graceful-shutdown.md](rules/graceful-shutdown.md).
+
+**Error handling**: Define a shared error base class → classify errors (operational vs programmer) → add async boundary handlers (`process.on('unhandledRejection')`) → propagate typed errors through the call stack → log with context before responding or crashing. See [rules/error-handling.md](rules/error-handling.md).
+
+**Diagnosing flaky tests**: Isolate the test with `--test-only` → check for shared state or timer dependencies → inspect async teardown order → add retry logic as a temporary diagnostic step → fix root cause. See [rules/flaky-tests.md](rules/flaky-tests.md).
+
+**Profiling a slow path**: Reproduce under realistic load → capture a CPU profile with `--cpu-prof` → identify hot functions → check for stream backpressure or unnecessary serialisation → validate improvement with a benchmark. See [rules/profiling.md](rules/profiling.md) and [rules/performance.md](rules/performance.md).
 
 ## How to use
 

--- a/skills/nodejs-core/SKILL.md
+++ b/skills/nodejs-core/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nodejs-core
-description: Deep Node.js internals expertise including C++ addons, V8, libuv, and build systems
+description: Debugs native module crashes, optimizes V8 performance, configures node-gyp builds, writes N-API/node-addon-api bindings, and diagnoses libuv event loop issues in Node.js. Use when working with C++ addons, native modules, binding.gyp, node-gyp errors, segfaults, memory leaks in native code, V8 optimization/deoptimization, libuv thread pool tuning, N-API or NAN bindings, build system failures, or any Node.js internals below the JavaScript layer.
 metadata:
   tags: nodejs, v8, libuv, cpp, native-addons, performance, debugging, internals
 ---
@@ -61,46 +61,59 @@ Read individual rule files for detailed explanations and code examples:
 
 ## Instructions
 
-You are the ultimate Node.js core developer, possessing the combined expertise of legendary Node.js contributors like James Snell, Colin Ihrig, Anna Henningsen, Matteo Collina, and Joyee Cheung. You have authored-level knowledge of C++, C, V8 JavaScript engine, and libuv event loop library.
+Apply deep knowledge of Node.js internals across these domains:
 
-Your expertise encompasses:
+- **Core architecture**: Node.js core modules and their C++ implementations, V8 GC and JIT, libuv event loop mechanics, thread pool behavior, startup/module-loading lifecycle
+- **Native development**: N-API, node-addon-api, and NAN addon development; V8 C++ API handle management; memory safety; native debugging with gdb/lldb
+- **Build systems**: node-gyp, gyp, ninja, make; cross-platform compilation; linker errors; dependency issues; platform-specific considerations (Windows, macOS, Linux, embedded)
+- **Performance & debugging**: Event loop profiling, memory leak detection in JS and native code, CPU flame graphs, V8 optimization/deoptimization tracing
 
-**Core Node.js Architecture:**
-- Deep understanding of Node.js core modules and their C++ implementations
-- V8 JavaScript engine internals, garbage collection, and optimization
-- libuv event loop mechanics, thread pool behavior, and async I/O
-- Node.js startup process, module loading, and runtime lifecycle
+### Quick-reference debugging commands
 
-**C++ and Native Development:**
-- Node.js C++ addon development using N-API, node-addon-api, and legacy NAN
-- V8 C++ API usage, handle management, and memory safety
-- Debugging native code with gdb, lldb, and platform-specific tools
-- Understanding of V8's compilation pipeline and optimization decisions
+**V8 optimization tracing:**
+```bash
+node --trace-opt --trace-deopt script.js
+# Checkpoint: confirm no unexpected deoptimization warnings before proceeding to profiling
+node --prof script.js && node --prof-process isolate-*.log > processed.txt
+```
 
-**Build Systems and Tooling:**
-- Node.js build system (gyp, ninja, make) and cross-platform compilation
-- Debugging compilation failures, linker errors, and dependency issues
-- Understanding of Node.js release process and version management
-- Platform-specific build considerations (Windows, macOS, Linux, embedded systems)
+**Event loop lag detection:**
+```bash
+node --trace-event-categories v8,node,node.async_hooks script.js
+```
 
-**Performance and Debugging:**
-- Event loop debugging and performance profiling
-- Memory leak detection in both JavaScript and native code
-- CPU profiling, flame graphs, and performance bottleneck identification
-- Understanding of Node.js performance characteristics and optimization strategies
+**Native addon debugging (gdb):**
+```bash
+gdb --args node --napi-modules ./build/Release/addon.node
+# Inside gdb:
+run
+bt        # backtrace on crash
+# Checkpoint: verify backtrace shows the expected call site before applying a fix
+```
 
-**Problem-Solving Approach:**
-1. **Diagnose systematically**: Start with the most likely causes based on symptoms
-2. **Provide specific debugging steps**: Include exact commands, tools, and techniques
-3. **Explain the underlying mechanics**: Help users understand why issues occur
-4. **Offer multiple solutions**: Provide both quick fixes and long-term architectural improvements
-5. **Reference authoritative sources**: Cite Node.js documentation, RFCs, and core team discussions when relevant
+**Heap snapshot for memory leaks:**
+```bash
+node --inspect script.js   # then open chrome://inspect, take heap snapshot
+# Checkpoint: compare two consecutive heap snapshots to confirm leak growth before and after the fix; run valgrind --leak-check=full node addon_test.js to confirm no native leaks remain
+```
 
-When addressing issues:
-- Always consider both JavaScript-level and native-level causes
-- Provide concrete debugging commands and tools
-- Explain performance implications and trade-offs
-- Suggest best practices aligned with Node.js core team recommendations
-- When discussing experimental features, clearly indicate their stability status
+### Node.js-specific diagnostic decision trees
 
-You write code examples that demonstrate deep understanding of Node.js internals and follow the patterns used in Node.js core itself. Your solutions are production-ready and consider edge cases that typical developers might miss.
+**Segfault / crash in native addon:**
+1. Is the crash reproducible with `node --napi-modules`? → Run `gdb`, capture `bt`
+2. Does `bt` point to a V8 handle scope issue? → Check `HandleScope` / `EscapableHandleScope` usage in the addon
+3. Does it point to a libuv callback? → Inspect async handle lifetime and `uv_close()` sequencing
+4. No clear C++ frame? → Check for JS-side type mismatches passed into the native binding
+
+**V8 deoptimization / performance regression:**
+1. Run `--trace-opt --trace-deopt` → identify the deoptimized function and reason (e.g., "not a Smi", "wrong map")
+2. Checkpoint: confirm the same function deoptimizes consistently across runs
+3. Inspect hidden class transitions (`--trace-ic`) and fix property addition order or type inconsistencies
+4. Re-run `--trace-opt` to confirm the function is now optimized
+
+**Build failure (node-gyp / binding.gyp):**
+1. Is it a missing header? → Verify `include_dirs` in `binding.gyp` and Node.js header installation
+2. Is it a linker error? → Check `libraries` and `link_settings` entries; confirm ABI compatibility
+3. Is it platform-specific? → Consult `rules/build-system.md` for Windows/macOS/Linux differences
+
+Always consider both JavaScript-level and native-level causes, explain performance implications and trade-offs, and indicate the stability status of any experimental features discussed. Code examples should demonstrate Node.js internals patterns and be production-ready, accounting for edge cases typical developers might miss.

--- a/skills/oauth/SKILL.md
+++ b/skills/oauth/SKILL.md
@@ -1,63 +1,186 @@
 ---
 name: oauth
-description: OAuth 2.0/2.1 specification expert with deep RFC knowledge and Fastify integration patterns
+description: Implements OAuth 2.0/2.1 authorization flows in Fastify applications — configures authorization code with PKCE, client credentials, device flow, refresh token rotation, JWT validation, and token introspection/revocation endpoints. Use when setting up authentication, authorization, login flows, access tokens, API security, or securing Fastify routes with OAuth; also applies when troubleshooting token validation errors, mismatched redirect URIs, CSRF issues, scope problems, or RFC 6749/6750/7636/8252/8628 compliance questions.
 metadata:
   tags: oauth, oauth2, security, authentication, authorization, jwt, fastify
 ---
 
 ## When to use
 
-Use this skill when you need expert guidance on:
-- OAuth 2.0/2.1 specifications
-- Implementation details and security considerations
-- Integration patterns with Fastify applications
-- Token validation, PKCE, and security best practices
+Use this skill when you need to:
+- Implement or debug an OAuth 2.0/2.1 flow in a Fastify application
+- Validate tokens, configure PKCE, or set up refresh token rotation
+- Secure Fastify routes and plugins with access-control middleware
+- Resolve RFC compliance questions or identify security anti-patterns
 
-## Instructions
+---
 
-You are an OAuth 2.0/2.1 specification author and expert implementer with deep knowledge of the complete OAuth ecosystem. You have intimate familiarity with RFC 6749, RFC 6750, RFC 7636 (PKCE), RFC 8252 (mobile apps), RFC 8628 (device flow), and OAuth 2.1 specifications. You are also a Fastify integration specialist with extensive experience implementing OAuth flows in production Fastify applications.
+## Step-by-step: Authorization Code + PKCE in Fastify
 
-Your expertise encompasses:
+### 1. Install dependencies
 
-**OAuth 2.0/2.1 Specification Mastery:**
-- Complete understanding of all grant types: authorization code, client credentials, device flow, refresh token flow
-- Security considerations including PKCE, state parameters, redirect URI validation, and token binding
-- Token formats (JWT, opaque), validation, introspection, and revocation
-- Scope management, audience validation, and claims processing
-- Error handling patterns and proper HTTP status codes
-- OAuth 2.1 security improvements and deprecated practices
+```bash
+npm install @fastify/oauth2 @fastify/cookie @fastify/session fastify-plugin
+```
 
-**Fastify Integration Expertise:**
-- Fastify plugin architecture for OAuth implementations
-- Request/response lifecycle hooks for token validation
-- Session management and cookie handling
-- Integration with Fastify's built-in validation and serialization
-- Performance optimization for high-throughput OAuth flows
-- Testing patterns for OAuth-enabled Fastify applications
+### 2. Register the OAuth plugin
 
-**When providing guidance:**
+```typescript
+// plugins/oauth.ts
+import fp from 'fastify-plugin'
+import oauth2, { OAuth2Namespace } from '@fastify/oauth2'
+import { FastifyInstance } from 'fastify'
 
-1. **Always reference the relevant RFC sections** when explaining OAuth concepts or requirements
-2. **Provide spec-compliant implementations** that follow security best practices
-3. **Include complete Fastify code examples** with proper TypeScript types when relevant
-4. **Address security implications** of every implementation choice
-5. **Explain the 'why' behind OAuth design decisions** to help users understand the specification rationale
-6. **Identify common anti-patterns** and explain why they violate the specification
-7. **Consider production concerns** like scalability, monitoring, and error handling
+export default fp(async function (fastify: FastifyInstance) {
+  fastify.register(oauth2, {
+    name: 'oauth2',
+    scope: ['openid', 'profile', 'email'],
+    credentials: {
+      client: {
+        id: process.env.CLIENT_ID!,
+        secret: process.env.CLIENT_SECRET!,
+      },
+      auth: {
+        authorizeHost: process.env.AUTH_SERVER!,
+        authorizePath: '/authorize',
+        tokenHost: process.env.AUTH_SERVER!,
+        tokenPath: '/token',
+      },
+    },
+    startRedirectPath: '/login',
+    callbackUri: process.env.CALLBACK_URI!,
+    pkce: 'S256',               // RFC 7636 — always use for public clients
+    generateStateFunction: (req) => req.session.state = crypto.randomUUID(),
+    checkStateFunction: (req, callback) =>
+      req.query.state === req.session.state ? callback() : callback(new Error('State mismatch')),
+  })
+})
+```
 
-**For Fastify-specific implementations:**
-- Use fastify-plugin for proper encapsulation
-- Leverage Fastify's schema validation for OAuth parameters
-- Implement proper error handling with Fastify's error system
-- Consider horizontal scaling implications (stateless design, Redis sessions)
-- Follow Fastify's async/await patterns and lifecycle hooks
+**Validation checkpoint:** Confirm `callbackUri` exactly matches a registered redirect URI at the authorization server before proceeding (RFC 6749 §3.1.2).
 
-**Security-first approach:**
-- Always validate redirect URIs against registered values
-- Implement proper CSRF protection with state parameters
-- Use PKCE for all public clients and recommend for confidential clients
-- Validate token signatures, expiration, audience, and issuer claims
-- Implement rate limiting and abuse detection
-- Follow principle of least privilege for scopes
+### 3. Handle the callback and exchange the code
 
-When users ask about OAuth implementation challenges, provide authoritative, specification-compliant solutions with clear explanations of security implications and Fastify integration patterns. If implementation details are ambiguous in the specs, explain the trade-offs and recommend industry best practices.
+```typescript
+// routes/auth.ts
+import { FastifyInstance } from 'fastify'
+
+export default async function authRoutes(fastify: FastifyInstance) {
+  fastify.get('/login/callback', async (request, reply) => {
+    // @fastify/oauth2 verifies state and exchanges code automatically
+    const tokenResponse = await fastify.oauth2.getAccessTokenFromAuthorizationCodeFlow(request)
+
+    // Store only what you need; never log the raw token
+    request.session.set('accessToken', tokenResponse.token.access_token)
+    request.session.set('refreshToken', tokenResponse.token.refresh_token)
+
+    return reply.redirect('/')
+  })
+
+  fastify.get('/logout', async (request, reply) => {
+    await request.session.destroy()
+    return reply.redirect('/')
+  })
+}
+```
+
+### 4. JWT validation middleware (token introspection hook)
+
+```typescript
+// hooks/verifyToken.ts
+import { FastifyRequest, FastifyReply } from 'fastify'
+import jwt from '@fastify/jwt'
+
+export async function verifyToken(request: FastifyRequest, reply: FastifyReply) {
+  try {
+    await request.jwtVerify()
+    // Validate required claims (RFC 7519)
+    const payload = request.user as Record<string, unknown>
+    const now = Math.floor(Date.now() / 1000)
+
+    if (typeof payload.exp === 'number' && payload.exp < now)
+      return reply.code(401).send({ error: 'token_expired' })
+
+    if (payload.iss !== process.env.EXPECTED_ISSUER)
+      return reply.code(401).send({ error: 'invalid_issuer' })
+
+    if (payload.aud !== process.env.EXPECTED_AUDIENCE)
+      return reply.code(401).send({ error: 'invalid_audience' })
+
+  } catch (err) {
+    return reply.code(401).send({ error: 'invalid_token', error_description: (err as Error).message })
+  }
+}
+```
+
+**Validation checkpoints:**
+- Verify `exp`, `iss`, `aud`, and `sub` on every request — never skip (RFC 7519 §4)
+- Use `fastify.jwt.verify` (asymmetric RS256/ES256) rather than HS256 for tokens issued by a third-party server
+
+### 5. Protecting routes
+
+```typescript
+// routes/api.ts
+import { FastifyInstance } from 'fastify'
+import { verifyToken } from '../hooks/verifyToken'
+
+export default async function apiRoutes(fastify: FastifyInstance) {
+  fastify.addHook('onRequest', verifyToken)   // applies to all routes in this scope
+
+  fastify.get('/me', {
+    schema: {
+      response: { 200: { type: 'object', properties: { sub: { type: 'string' } } } },
+    },
+  }, async (request) => {
+    const user = request.user as { sub: string }
+    return { sub: user.sub }
+  })
+}
+```
+
+### 6. Refresh token rotation
+
+```typescript
+async function refreshAccessToken(fastify: FastifyInstance, refreshToken: string) {
+  const newToken = await fastify.oauth2.getNewAccessTokenUsingRefreshTokenFlow({ refresh_token: refreshToken })
+
+  // Always replace the stored refresh token if rotation is in use (RFC 6749 §10.4)
+  return {
+    accessToken: newToken.token.access_token,
+    refreshToken: newToken.token.refresh_token ?? refreshToken,
+  }
+}
+```
+
+---
+
+## Security checklist
+
+| Requirement | RFC reference |
+|---|---|
+| Validate redirect URI against allowlist | RFC 6749 §3.1.2 |
+| PKCE (S256) for all public clients | RFC 7636 §4.2 |
+| Validate `state` to prevent CSRF | RFC 6749 §10.12 |
+| Validate `iss`, `aud`, `exp` on every JWT | RFC 7519 §4 |
+| Rotate refresh tokens on every use | RFC 6749 §10.4 |
+| Use HTTPS everywhere; reject HTTP redirect URIs | RFC 6749 §3.1.2.1 |
+| Rate-limit token endpoints | OAuth 2.1 §7 |
+
+---
+
+## Common anti-patterns
+
+- **Storing tokens in localStorage** — use `HttpOnly`, `Secure`, `SameSite=Strict` cookies instead
+- **Skipping audience validation** — allows token reuse across services
+- **Using implicit flow** — deprecated in OAuth 2.1; use authorization code + PKCE
+- **Accepting `response_type=token` in browser apps** — tokens in URL fragments leak in logs/referrers
+- **Symmetric signing (HS256) for third-party tokens** — use RS256/ES256 with JWKS endpoint
+
+---
+
+## Further implementation references
+
+- See `DEVICE_FLOW.md` for device authorization flow (RFC 8628) implementation
+- See `TOKEN_VALIDATION.md` for JWKS rotation, caching strategies, and opaque token introspection
+- See `CLIENT_CREDENTIALS.md` for machine-to-machine service authentication patterns
+- See `MOBILE_OAUTH.md` for native/mobile app flows (RFC 8252) and custom URI schemes

--- a/skills/octocat/SKILL.md
+++ b/skills/octocat/SKILL.md
@@ -1,54 +1,43 @@
 ---
 name: octocat
-description: Git and GitHub wizard using gh CLI for all git operations and GitHub interactions
+description: Handles git and GitHub operations using the gh CLI. Use when the user asks about pull requests (PRs), GitHub issues, repo management, branching, merging, rebasing, cherry-picking, merge conflict resolution, commit history cleanup, pre-commit hook debugging, GitHub Actions workflows, or releases. Covers creating and reviewing PRs, watching CI checks, interactive rebasing, branch cleanup, submodule management, and repository archaeology with git log/blame/bisect.
 metadata:
   tags: git, github, gh-cli, version-control, merge-conflicts, pull-requests
 ---
 
 ## When to use
 
-Use this skill proactively for:
-- All git operations and GitHub interactions
-- Merge conflicts resolution
-- Pre-commit hook fixes
-- Repository management
-- Pull request creation and management
-- Any git/GitHub workflow issues
+Use this skill for:
+- Creating, reviewing, and managing pull requests and GitHub issues
+- Merge conflict resolution and history rewriting
+- Pre-commit hook debugging and fixes
+- Branch management and cleanup
+- GitHub Actions workflow optimization
+- Any git command or GitHub workflow question
 
 ## Instructions
 
-You are the Octocat - a Git and GitHub wizard who lives and breathes version control. You wield the gh CLI like a master swordsman and can untangle the most complex git situations with grace and precision.
-
 When invoked:
 1. Assess the git/GitHub situation immediately
-2. Use gh CLI for all GitHub operations (never web interface suggestions)
+2. Use gh CLI for all GitHub operations (never suggest the web interface)
 3. Handle complex git operations with surgical precision
 4. Fix pre-commit hook issues or delegate to typescript-magician for TypeScript linting
-5. Never alter git signing key configuration; if signing is already enabled and configured, use it. Otherwise, proceed without signing.
+5. Never alter git signing key configuration; if signing is already enabled and configured, use it. Otherwise, proceed without signing
 6. NEVER include "Co-Authored-By: Claude" or similar AI attribution
 
-Your superpowers include:
-- Advanced git operations (rebase, cherry-pick, bisect, worktrees)
-- gh CLI mastery for issues, PRs, releases, and workflows
-- Merge conflict resolution and history rewriting
-- Branch management and cleanup strategies
-- Pre-commit hook debugging and fixes
-- Respecting existing commit-signing setup without changing user signing keys
-- GitHub Actions workflow optimization
+## Capabilities
 
-Git workflow expertise:
-- Interactive rebasing for clean history
-- Strategic commit splitting and squashing
+**Advanced git operations:**
+- Interactive rebasing for clean history (commit splitting, squashing)
+- Cherry-pick, bisect, worktrees
 - Advanced merge strategies
 - Submodule and subtree management
 - Git hooks setup and maintenance
 - Repository archaeology with git log/blame/show
 
-GitHub operations via gh CLI:
+**GitHub operations via gh CLI:**
 - Create/manage PRs with proper templates
 - Open PRs with explicit base/head and structured content, e.g. `gh pr create --base main --head <branch> --title "<title>" --body-file <file>`
-- Prefer `--body-file` (or stdin with `--body-file -`) for multi-line PR bodies to avoid broken escaping
-- If inline body text is required, use shell-safe newlines (e.g. Bash ANSI-C quoting `$'line1\n\nline2'`) instead of raw `\n`
 - After opening a PR, wait for CI with `gh pr checks <num> --watch 2>&1` and proactively fix failures
 - Validate unfamiliar gh commands first with `gh help <command>` before using them in guidance
 - Handle issues and project boards
@@ -56,19 +45,10 @@ GitHub operations via gh CLI:
 - Configure repository settings
 - Automate workflows and notifications
 
-## PR Body Formatting (Important)
+## PR Body Formatting
 
-When creating PRs with `gh pr create`, the `--body` flag has escaping issues with newlines. The `\n` sequences get escaped as literal characters instead of actual newlines.
+When creating PRs with `gh pr create`, use `--body-file` to avoid newline escaping issues with the `--body` flag.
 
-### The Problem
-❌ This produces literal `\n` in the PR body:
-```bash
-gh pr create --body "Line 1\nLine 2\nLine 3"
-```
-
-### Solutions
-
-**Option 1: Use `--body-file` (Recommended)**
 ```bash
 cat > /tmp/pr-body.md << 'EOF'
 Line 1
@@ -79,41 +59,19 @@ EOF
 gh pr create --body-file /tmp/pr-body.md
 ```
 
-**Option 2: Use `printf` with proper escaping**
-```bash
-gh pr create --body "$(printf 'Line 1\n\nLine 2\nLine 3')"
-```
+Using a temporary file is cleaner, more reliable, and easier to debug — especially for complex PR descriptions with markdown formatting.
 
-**Option 3: Use `echo -e` (works in bash)**
-```bash
-gh pr create --body "$(echo -e "Line 1\n\nLine 2\nLine 3")"
-```
+## Validation Checkpoints for Complex Operations
 
-**Option 4: Multi-line with heredoc in shell**
-```bash
-body=$(cat << 'EOF'
-Line 1
+**Interactive rebase:** `git rebase -i <base>` → verify with `git log --oneline -n 10` → on conflict: resolve, `git add <file>`, `git rebase --continue` → abort anytime with `git rebase --abort`.
 
-Line 2
-Line 3
-EOF
-)
-gh pr create --body "$body"
-```
+**Merge conflict resolution:** `git status` (find conflicts) → inspect with `git diff` or open file → resolve all markers → `git add <resolved-file>` → `git merge --continue` (or `git rebase --continue`) → confirm clean state with `git status`.
 
-### Best Practice
-For complex PR descriptions with formatting, always use `--body-file` with a temporary file. It's cleaner, more reliable, and easier to debug.
+**Branch cleanup:** `git branch --merged main` → `git branch -d <branch>` → `git push origin --delete <branch>` → `git fetch --prune`.
 
-Pre-commit hook philosophy:
-- Fix linting errors directly when possible
-- Delegate TypeScript issues to the typescript-magician
-- Ensure hooks are fast and reliable
-- Provide clear error messages and solutions
+## Commit Signing and Attribution Rules
 
-Commit signing rules:
 - NEVER alter git signing key settings (`user.signingkey`) or signing mode in user/repo config
 - If commit signing is already enabled and correctly configured, create signed commits using the existing setup
-- If signing is not enabled/configured, do not force or configure signing; continue without it
-- NEVER add AI co-authorship attributions
-
-You take pride in clean git history, meaningful commit messages, and seamless GitHub workflows. When things break, you don't panic - you debug methodically and fix with confidence.
+- If signing is not enabled/configured, do not force or configure signing; proceed without it
+- NEVER add AI co-authorship attributions (e.g. "Co-Authored-By: Claude")

--- a/skills/snipgrapher/SKILL.md
+++ b/skills/snipgrapher/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: snipgrapher
-description: Configure and use snipgrapher to generate polished code snippet images
+description: Configures and uses snipgrapher to generate polished code snippet images, including syntax-highlighted PNGs, SVGs, and WebP exports with custom themes, profiles, and styling options. Use when the user wants to create code screenshots, turn code into shareable images, generate pretty code snippets for docs or social posts, produce syntax-highlighted images from source files, or explicitly mentions snipgrapher. Supports single-file renders, batch jobs, watch mode, and reusable named profiles via the snipgrapher CLI or npx.
 metadata:
   tags: snipgrapher, snippets, images, svg, png, webp, cli
 ---
@@ -12,6 +12,27 @@ Use this skill when you need to:
 - Configure reusable snippet rendering defaults
 - Batch-render snippet assets for docs, social posts, or changelogs
 - Use published `snipgrapher` from npm to generate snippet images
+
+## Quick start
+
+Render a single file to a PNG immediately with no config required:
+
+```bash
+npx snipgrapher render file.ts -o output.png
+```
+
+For ongoing use, initialise a project config first, then render:
+
+```bash
+npx snipgrapher init          # creates snipgrapher.config.json
+npx snipgrapher render file.ts --profile default -o output.png
+```
+
+After rendering, verify the output exists and is non-zero in size before treating the job as successful:
+
+```bash
+ls -lh output.png   # confirm file exists and size > 0
+```
 
 ## How to use
 
@@ -26,3 +47,12 @@ Read these rule files in order:
 - **Reproducible output**: prefer named profiles and explicit output paths
 - **Portable commands**: use command patterns that work with installed binaries and `npx`
 - **Automation-friendly**: rely on CLI flags/config/env precedence intentionally
+
+## Troubleshooting common render failures
+
+If a render fails or produces an unexpected output, check for these common causes:
+
+- **Missing fonts**: ensure any custom font specified in the profile or config is installed on the system
+- **Unsupported syntax**: confirm the language/extension is supported by snipgrapher; fall back to plain text highlighting if not
+- **Empty or corrupt output**: re-run with `--verbose` (if supported) to surface error details, and verify the input file is readable and non-empty
+- **Profile not found**: run `npx snipgrapher init` to regenerate `snipgrapher.config.json` if the config file is missing or malformed

--- a/skills/typescript-magician/SKILL.md
+++ b/skills/typescript-magician/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: typescript-magician
-description: TypeScript wizard specializing in advanced type systems, complex generics, and eliminating any types
+description: Designs complex generic types, refactors `any` types to strict alternatives, creates type guards and utility types, and resolves TypeScript compiler errors. Use when the user asks about TypeScript (TS) types, generics, type inference, type guards, removing `any` types, strict typing, type errors, `infer`, `extends`, conditional types, mapped types, template literal types, branded/opaque types, or utility types like `Partial`, `Record`, `ReturnType`, and `Awaited`.
 metadata:
   tags: typescript, types, generics, type-safety, advanced-typescript
 ---
 
 ## When to use
 
-Use this skill proactively for:
+Use this skill for:
 - TypeScript errors and type challenges
 - Eliminating `any` types from codebases
 - Complex generics and type inference issues
@@ -15,16 +15,14 @@ Use this skill proactively for:
 
 ## Instructions
 
-You are the Magician - a TypeScript wizard with Matt Pocock's deep expertise in advanced TypeScript patterns and type system mastery. You have zero tolerance for `any` types and specialize in crafting elegant, type-safe solutions.
-
 When invoked:
-1. Analyze TypeScript errors and diagnostics thoroughly
-2. Identify the root cause of type issues
+1. Run `tsc --noEmit` to capture the full error output before making changes
+2. Identify the root cause of type issues (unsound inference, missing constraints, implicit `any`, etc.)
 3. Craft precise, type-safe solutions using advanced TypeScript features
-4. Eliminate all `any` types with proper typing
-5. Verify solutions compile without errors
+4. Eliminate all `any` types with proper typing — validate each replacement still satisfies call sites
+5. Confirm the fix compiles cleanly with a second `tsc --noEmit` pass
 
-Your magical toolkit includes:
+Capabilities include:
 - Advanced generics and conditional types
 - Template literal types and mapped types
 - Utility types and type manipulation
@@ -40,12 +38,55 @@ For every TypeScript challenge:
 - Include comprehensive type tests
 - Ensure full IntelliSense support
 
-Your mantras:
-- "There is no `any` - only undiscovered types"
-- "If it compiles, the types are teaching us something"
-- "Type safety is not a constraint, it's a superpower"
+## Quick Examples
 
-Transform TypeScript confusion into type-safe clarity with surgical precision.
+### Eliminating `any` with generics
+
+**Before**
+```ts
+function getProperty(obj: any, key: string): any {
+  return obj[key];
+}
+```
+
+**After**
+```ts
+function getProperty<T, K extends keyof T>(obj: T, key: K): T[K] {
+  return obj[key];
+}
+// getProperty({ name: "Alice" }, "name") → inferred as string ✓
+```
+
+### Narrowing an unknown API response
+
+**Before**
+```ts
+async function fetchUser(): Promise<any> {
+  const res = await fetch("/api/user");
+  return res.json();
+}
+```
+
+**After**
+```ts
+interface User { id: number; name: string }
+
+function isUser(value: unknown): value is User {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "id" in value &&
+    "name" in value
+  );
+}
+
+async function fetchUser(): Promise<User> {
+  const res = await fetch("/api/user");
+  const data: unknown = await res.json();
+  if (!isUser(data)) throw new Error("Invalid user shape");
+  return data;
+}
+```
 
 ## Reference
 


### PR DESCRIPTION
Hullo @mcollina 👋

I ran your skills through `tessl skill review` at work and found some targeted improvements. 

<img width="1312" height="1290" alt="score_card" src="https://github.com/user-attachments/assets/7cdd25cf-6213-4871-8465-ee7c1588c218" />

Here's the before/after:

| Skill | Before | After | Change |
|-------|--------|-------|--------|
| documentation | 36% | 89% | +53% |
| fastify | 48% | 100% | +52% |
| init | 70% | 96% | +26% |
| linting-neostandard-eslint9 | 53% | 100% | +47% | | node | 59% | 100% | +41% |
| nodejs-core | 45% | 100% | +55% |
| oauth | 22% | 100% | +78% |
| octocat | 44% | 96% | +52% |
| snipgrapher | 56% | 100% | +44% |
| typescript-magician | 45% | 100% | +55% |

<details>
<summary>Changes made</summary>

- **documentation**: Replaced vague persona preamble with actionable instructions, added decision checklist table mapping user signals to Diataxis documentation types, added type-specific patterns with structural templates and example intros, added validation criteria table
- **fastify**: Expanded frontmatter description with concrete actions and trigger terms, added quick-start runnable TypeScript server example, added recommended reading order for common scenarios
- **init**: Expanded frontmatter description with explicit trigger scenarios and natural language trigger terms (body content unchanged — it was already excellent)
- **linting-neostandard-eslint9**: Expanded description with trigger scenarios, added quick-start section with copy-paste commands and minimal eslint.config.js example, added common setup workflow with validation checkpoints
- **node**: Expanded description with trigger terms for type stripping and Node 22 TypeScript features, added minimal code example demonstrating type stripping, added common workflows section with step-by-step sequences
- **nodejs-core**: Replaced persona/role-play language with direct instructions, condensed domain expertise into structured list, added copy-paste debugging commands with verification checkpoints, added diagnostic decision trees for segfaults, V8 deopts, and build failures
- **oauth**: Completely restructured from abstract persona description to concrete 6-step implementation workflow with executable TypeScript/Fastify code examples, added security checklist with RFC references, added common anti-patterns section
- **octocat**: Removed persona/flavor text, consolidated redundant sections, trimmed PR body formatting to recommended approach only, added validation checkpoints for complex operations, reduced from 120 to 78 lines while preserving all essential content
- **snipgrapher**: Expanded description with output format details and trigger terms, added quick-start section with three copy-paste commands, added troubleshooting section for common render failures
- **typescript-magician**: Replaced vague "wizard" persona with concrete actions, added explicit trigger terms for TS concepts, made workflow steps concrete with tsc --noEmit commands, added before/after code examples for eliminating any and type guards

</details>

Honest disclosure — I work at @tesslio with Simon, who I understand pinged you on X. :) 

If you want to run reviews, evals and optimizations yourself, just `npm install @tessl/cli` then run `tessl skill review path/to/your/SKILL.md`, and click [here](https://tessl.io/registry/skills/submit) to find out more.

Thanks in advance 🙏