### PR TITLE
Adding skills to Tessl registry as tiles (step before creating evals)

### DIFF
--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -1,0 +1,21 @@
+name: Publish Tile
+
+permissions:
+id-token: write # Required for OIDC token
+contents: read # Required to checkout the repository
+
+on:
+push:
+branches:
+- main # Trigger on push / merge to main
+
+jobs:
+publish:
+runs-on: ubuntu-latest
+steps:
+- uses: actions/checkout@v6
+- uses: tesslio/publish@main
+with:
+token: ${{ secrets.TESSL_API_TOKEN }}
+# path: './path/to/tile' # Optional, defaults to current directory”
+

--- a/.github/workflows/publish-tile.yml
+++ b/.github/workflows/publish-tile.yml
@@ -1,21 +1,34 @@
 name: Publish Tile
 
 permissions:
-id-token: write # Required for OIDC token
-contents: read # Required to checkout the repository
+  id-token: write # Required for OIDC token
+  contents: read # Required to checkout the repository
 
 on:
-push:
-branches:
-- main # Trigger on push / merge to main
+  push:
+    branches:
+      - main # Trigger on push / merge to main
 
 jobs:
-publish:
-runs-on: ubuntu-latest
-steps:
-- uses: actions/checkout@v6
-- uses: tesslio/publish@main
-with:
-token: ${{ secrets.TESSL_API_TOKEN }}
-# path: './path/to/tile' # Optional, defaults to current directory”
-
+  publish:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        tile:
+          - skills/documentation
+          - skills/fastify
+          - skills/init
+          - skills/linting-neostandard-eslint9
+          - skills/node
+          - skills/nodejs-core
+          - skills/oauth
+          - skills/octocat
+          - skills/skill-optimizer
+          - skills/snipgrapher
+          - skills/typescript-magician
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tesslio/publish@main
+        with:
+          token: ${{ secrets.TESSL_API_TOKEN }}
+          path: ${{ matrix.tile }}

--- a/skills/documentation/tile.json
+++ b/skills/documentation/tile.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcollina/documentation",
+  "version": "0.1.0",
+  "private": false,
+  "summary": "Creates, structures, and reviews technical documentation following the Diátaxis framework (tutorials, how-to guides, reference, and explanation pages). Use when a user needs to write or reorganize docs, structure a tutorial vs. a how-to guide, build reference docs or API documentation, create explanation pages, choose between Diátaxis documentation types, or improve existing documentation structure. Trigger terms include: documentation structure, Diátaxis, tutorials vs how-to guides, organize docs, user guide, reference docs, technical writing.",
+  "skills": {
+    "documentation": {
+      "path": "SKILL.md"
+    }
+  }
+}

--- a/skills/fastify/tile.json
+++ b/skills/fastify/tile.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcollina/fastify-best-practices",
+  "version": "0.1.0",
+  "private": false,
+  "summary": "Guides development of Fastify Node.js backend servers and REST APIs using TypeScript or JavaScript. Use when building, configuring, or debugging a Fastify application — including defining routes, implementing plugins, setting up JSON Schema validation, handling errors, optimising performance, managing authentication, configuring CORS and security headers, integrating databases, working with WebSockets, and deploying to production. Covers the full Fastify request lifecycle (hooks, serialization, logging with Pino) and TypeScript integration via strip types. Trigger terms: Fastify, Node.js server, REST API, API routes, backend framework, fastify.config, server.ts, app.ts.",
+  "skills": {
+    "fastify-best-practices": {
+      "path": "SKILL.md"
+    }
+  }
+}

--- a/skills/init/tile.json
+++ b/skills/init/tile.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcollina/init",
+  "version": "0.1.0",
+  "private": false,
+  "summary": "Creates, updates, or optimizes an AGENTS.md file for a repository with minimal, high-signal instructions covering non-discoverable coding conventions, tooling quirks, workflow preferences, and project-specific rules that agents cannot infer from reading the codebase. Use when setting up agent instructions or Claude configuration for a new repository, when an existing AGENTS.md is too long, generic, or stale, when agents repeatedly make avoidable mistakes, or when repository workflows have changed and the agent configuration needs pruning. Applies a discoverability filter—omitting anything Claude can learn from README, code, config, or directory structure—and a quality gate to verify each line remains accurate and operationally significant.",
+  "skills": {
+    "init": {
+      "path": "SKILL.md"
+    }
+  }
+}

--- a/skills/linting-neostandard-eslint9/tile.json
+++ b/skills/linting-neostandard-eslint9/tile.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcollina/linting-neostandard-eslint9",
+  "version": "0.1.0",
+  "private": false,
+  "summary": "Configures ESLint v9 flat config and neostandard for JavaScript and TypeScript projects, including migrating from legacy `.eslintrc*` files or the `standard` package. Use when you need to set up or fix linting with `eslint.config.js` or `eslint.config.mjs`, troubleshoot lint errors, configure neostandard rules, migrate from `.eslintrc` to flat config, or integrate linting into CI pipelines and pre-commit hooks.",
+  "skills": {
+    "linting-neostandard-eslint9": {
+      "path": "SKILL.md"
+    }
+  }
+}

--- a/skills/node/tile.json
+++ b/skills/node/tile.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcollina/node-best-practices",
+  "version": "0.1.0",
+  "private": false,
+  "summary": "Provides domain-specific best practices for Node.js development with TypeScript, covering type stripping, async patterns, error handling, streams, modules, testing, performance, caching, logging, and more. Use when setting up Node.js projects with native TypeScript support, configuring type stripping (--experimental-strip-types), writing Node 22+ TypeScript without a build step, or when the user mentions 'native TypeScript in Node', 'strip types', 'Node 22 TypeScript', '.ts files without compilation', 'ts-node alternative', or needs guidance on error handling, graceful shutdown, flaky tests, profiling, or environment configuration in Node.js. Helps configure tsconfig.json for type stripping, set up package.json scripts, handle module resolution and import extensions, and apply robust patterns across the full Node.js stack.",
+  "skills": {
+    "node-best-practices": {
+      "path": "SKILL.md"
+    }
+  }
+}

--- a/skills/nodejs-core/tile.json
+++ b/skills/nodejs-core/tile.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcollina/nodejs-core",
+  "version": "0.1.0",
+  "private": false,
+  "summary": "Debugs native module crashes, optimizes V8 performance, configures node-gyp builds, writes N-API/node-addon-api bindings, and diagnoses libuv event loop issues in Node.js. Use when working with C++ addons, native modules, binding.gyp, node-gyp errors, segfaults, memory leaks in native code, V8 optimization/deoptimization, libuv thread pool tuning, N-API or NAN bindings, build system failures, or any Node.js internals below the JavaScript layer.",
+  "skills": {
+    "nodejs-core": {
+      "path": "SKILL.md"
+    }
+  }
+}

--- a/skills/oauth/tile.json
+++ b/skills/oauth/tile.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcollina/oauth",
+  "version": "0.1.0",
+  "private": false,
+  "summary": "Implements OAuth 2.0/2.1 authorization flows in Fastify applications — configures authorization code with PKCE, client credentials, device flow, refresh token rotation, JWT validation, and token introspection/revocation endpoints. Use when setting up authentication, authorization, login flows, access tokens, API security, or securing Fastify routes with OAuth; also applies when troubleshooting token validation errors, mismatched redirect URIs, CSRF issues, scope problems, or RFC 6749/6750/7636/8252/8628 compliance questions.",
+  "skills": {
+    "oauth": {
+      "path": "SKILL.md"
+    }
+  }
+}

--- a/skills/octocat/tile.json
+++ b/skills/octocat/tile.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcollina/octocat",
+  "version": "0.1.0",
+  "private": false,
+  "summary": "Handles git and GitHub operations using the gh CLI. Use when the user asks about pull requests (PRs), GitHub issues, repo management, branching, merging, rebasing, cherry-picking, merge conflict resolution, commit history cleanup, pre-commit hook debugging, GitHub Actions workflows, or releases. Covers creating and reviewing PRs, watching CI checks, interactive rebasing, branch cleanup, submodule management, and repository archaeology with git log/blame/bisect.",
+  "skills": {
+    "octocat": {
+      "path": "SKILL.md"
+    }
+  }
+}

--- a/skills/snipgrapher/tile.json
+++ b/skills/snipgrapher/tile.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcollina/snipgrapher",
+  "version": "0.1.0",
+  "private": false,
+  "summary": "Configures and uses snipgrapher to generate polished code snippet images, including syntax-highlighted PNGs, SVGs, and WebP exports with custom themes, profiles, and styling options. Use when the user wants to create code screenshots, turn code into shareable images, generate pretty code snippets for docs or social posts, produce syntax-highlighted images from source files, or explicitly mentions snipgrapher. Supports single-file renders, batch jobs, watch mode, and reusable named profiles via the snipgrapher CLI or npx.",
+  "skills": {
+    "snipgrapher": {
+      "path": "SKILL.md"
+    }
+  }
+}

--- a/skills/typescript-magician/tile.json
+++ b/skills/typescript-magician/tile.json
@@ -1,0 +1,11 @@
+{
+  "name": "mcollina/typescript-magician",
+  "version": "0.1.0",
+  "private": false,
+  "summary": "Designs complex generic types, refactors `any` types to strict alternatives, creates type guards and utility types, and resolves TypeScript compiler errors. Use when the user asks about TypeScript (TS) types, generics, type inference, type guards, removing `any` types, strict typing, type errors, `infer`, `extends`, conditional types, mapped types, template literal types, branded/opaque types, or utility types like `Partial`, `Record`, `ReturnType`, and `Awaited`.",
+  "skills": {
+    "typescript-magician": {
+      "path": "SKILL.md"
+    }
+  }
+}


### PR DESCRIPTION
Hey Matteo,

Added some tile.json files to allow versioning, and auto publish to Tessl when you make skill changes, and bump the versions in the tile.json files. 

In order for the GitHub action to work you'll need to:

1. Log into [Tessl](https://tessl.io/registry) on then navigate to https://tessl.io/account/api-keys. Create a new API key. Copy the value and store it as a Repository Secret. Provide the name: TESSL_API_TOKEN.

2. Give me your username, and I'll add you to a new workspace I created called mcollina. 

3. if you then merge the PR, we see the action publish all your skills up onto Tessl with a version, and I can then set up some eval scenarios separately that will then stay with each skill.