### PR TITLE
build(tooling): restore lint and typecheck in repository

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,19 @@
+import js from '@eslint/js';
+import globals from 'globals';
+import tseslint from 'typescript-eslint';
+
+export default [
+  {
+    ignores: ['node_modules/**'],
+  },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.{js,mjs,cjs,ts}'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+  },
+];

--- a/package.json
+++ b/package.json
@@ -12,7 +12,12 @@
 		"test": "node --test"
 	},
 	"devDependencies": {
+		"@eslint/js": "^10.0.1",
 		"@types/node": "^22.0.0",
-		"typescript": "^5.7.0"
+		"close-with-grace": "^2.5.0",
+		"eslint": "^10.0.3",
+		"globals": "^17.4.0",
+		"typescript": "^5.7.0",
+		"typescript-eslint": "^8.57.0"
 	}
 }

--- a/skills/node/rules/assets/graceful-server.ts
+++ b/skills/node/rules/assets/graceful-server.ts
@@ -74,7 +74,7 @@ export async function main(): Promise<void> {
 }
 
 // Run if executed directly
-const isMain = import.meta.url === `file://${process.argv[1]}`;
+const isMain = process.argv[1]?.endsWith('graceful-server.ts') ?? false;
 if (isMain) {
   main().catch(console.error);
 }


### PR DESCRIPTION
## Summary
This follow-up PR fixes the pre-existing repository tooling problems that were blocking local validation:

- `npm run typecheck` failed due missing `close-with-grace` type/module resolution and module-mode mismatch in an asset file.
- `npm run lint` failed because ESLint wasn't installed/configured.

### Changes
- Added dev dependencies:
  - `close-with-grace`
  - `eslint`
  - `@eslint/js`
  - `typescript-eslint`
  - `globals`
- Added `eslint.config.mjs` (flat config) for JS/TS linting in Node environments.
- Updated `skills/node/rules/assets/graceful-server.ts` direct-run check to avoid `import.meta` in this repo's current module setup.

## Validation
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅

Refs: https://github.com/mcollina/skills/pull/17
