### PR TITLE
docs(node): add diagnostics playbook for stuck processes and hanging tests

### DIFF
--- a/skills/node/SKILL.md
+++ b/skills/node/SKILL.md
@@ -9,6 +9,8 @@ metadata:
 
 Use this skill whenever you are dealing with Node.js code to obtain domain-specific knowledge for building robust, performant, and maintainable Node.js applications.
 
+High-signal activation cues include: `node --test` hangs, process does not exit, CI timeout after tests, open handles, flaky tests, graceful shutdown, profiling, and TypeScript type stripping.
+
 ## TypeScript with Type Stripping
 
 When writing TypeScript for Node.js, use **type stripping** (Node.js 22.6+) instead of build tools like ts-node or tsx. Type stripping runs TypeScript directly by removing type annotations at runtime without transpilation.
@@ -46,6 +48,8 @@ For multi-step processes, follow these high-level sequences before consulting th
 
 **Diagnosing flaky tests**: Isolate the test with `--test-only` → check for shared state or timer dependencies → inspect async teardown order → add retry logic as a temporary diagnostic step → fix root cause. See [rules/flaky-tests.md](rules/flaky-tests.md).
 
+**Diagnosing stuck processes/tests** (`node --test` hangs, "process did not exit", CI timeout, open handles): isolate file/test → run with explicit timeout/reporter → inspect handles via `why-is-node-running` (`SIGUSR1`) → patch deterministic teardown in resource-creation scope → rerun isolated + full suite until stable. See [rules/stuck-processes-and-tests.md](rules/stuck-processes-and-tests.md).
+
 **Profiling a slow path**: Reproduce under realistic load → capture a CPU profile with `--cpu-prof` → identify hot functions → check for stream backpressure or unnecessary serialisation → validate improvement with a benchmark. See [rules/profiling.md](rules/profiling.md) and [rules/performance.md](rules/performance.md).
 
 ## High-priority activation checklist (streams + caching)
@@ -81,6 +85,7 @@ Read individual rule files for detailed explanations and code examples:
 - [rules/modules.md](rules/modules.md) - ES Modules and CommonJS patterns
 - [rules/testing.md](rules/testing.md) - Testing strategies for Node.js applications
 - [rules/flaky-tests.md](rules/flaky-tests.md) - Identifying and diagnosing flaky tests with node:test
+- [rules/stuck-processes-and-tests.md](rules/stuck-processes-and-tests.md) - Diagnosing processes that do not exit and tests that get stuck
 - [rules/node-modules-exploration.md](rules/node-modules-exploration.md) - Navigating and analyzing node_modules directories
 - [rules/performance.md](rules/performance.md) - Performance optimization techniques
 - [rules/caching.md](rules/caching.md) - Caching patterns and libraries

--- a/skills/node/SKILL.md
+++ b/skills/node/SKILL.md
@@ -9,8 +9,6 @@ metadata:
 
 Use this skill whenever you are dealing with Node.js code to obtain domain-specific knowledge for building robust, performant, and maintainable Node.js applications.
 
-High-signal activation cues include: `node --test` hangs, process does not exit, CI timeout after tests, open handles, flaky tests, graceful shutdown, profiling, and TypeScript type stripping.
-
 ## TypeScript with Type Stripping
 
 When writing TypeScript for Node.js, use **type stripping** (Node.js 22.6+) instead of build tools like ts-node or tsx. Type stripping runs TypeScript directly by removing type annotations at runtime without transpilation.

--- a/skills/node/rules/stuck-processes-and-tests.md
+++ b/skills/node/rules/stuck-processes-and-tests.md
@@ -1,0 +1,124 @@
+---
+name: stuck-processes-and-tests
+description: Diagnosing Node.js processes that do not exit and tests that get stuck
+metadata:
+  tags: node, debugging, testing, hangs, open-handles, diagnostics
+---
+
+# Diagnosing Stuck Node.js Processes and Hanging Tests
+
+## Activation triggers (apply this rule immediately)
+
+Use this rule when prompts/logs include any of:
+- "`node --test` hangs" / "test run never exits"
+- "CI timed out" after tests appear done
+- "process is still running" / "did not exit cleanly"
+- "open handles" / "active handles"
+- "passes alone, hangs in full suite"
+
+## Non-negotiable checklist (all 5 required)
+
+1. **Isolate first**: reproduce with one file, then one test name.
+2. **Fail fast**: run with explicit timeout + reporter so hangs produce location context.
+3. **Capture handles**: run `why-is-node-running` and record the reported handle owner.
+4. **Patch teardown in the same scope that created the resource** (`t.after(...)`, await close/terminate/disconnect).
+5. **Verify stability**: repeat isolated test many times, then run full suite.
+
+Do **not** mark the issue fixed unless step 5 passes.
+
+## Command path (run in order)
+
+```bash
+# 1) Reproduce full command with fail-fast settings
+node --test --test-reporter=spec --test-timeout=15000
+
+# 2) Isolate file, then test name
+node --test --test-timeout=15000 path/to/file.test.ts
+node --test --test-timeout=15000 --test-name-pattern="should close resources" path/to/file.test.ts
+
+# 3) Dump active handles when hung
+node --import why-is-node-running/include --test path/to/file.test.ts
+# in another shell, send SIGUSR1 to printed PID
+kill -SIGUSR1 <pid>
+
+# 4) Stress rerun isolated repro (Linux: timeout, macOS: gtimeout)
+TIMEOUT_BIN="$(command -v timeout || command -v gtimeout)"
+for i in {1..30}; do
+  "$TIMEOUT_BIN" 30s node --test path/to/file.test.ts || { echo "failed on run $i"; break; }
+done
+```
+
+### `why-is-node-running` install note
+
+- ESM / modern Node: `npm i -D why-is-node-running`
+- older CommonJS projects: `npm i -D why-is-node-running@v2`
+
+Use it for diagnostics only; gate noisy output behind an environment flag in CI.
+
+## High-probability root causes
+
+- HTTP server started but never closed (`server.close()` not awaited)
+- `setInterval` left running (or timer not `unref()`ed when appropriate)
+- DB/Redis/Kafka clients not disconnected
+- worker threads, child processes, or message channels left alive
+- file watchers / readline interfaces still open
+- unresolved promises from fire-and-forget async code
+- teardown hooks that throw before cleanup completes
+
+## Integrated fix example (CI hangs after tests appear complete)
+
+**Symptom:** CI times out; local full-suite run hangs after most tests pass.
+
+### Step sequence
+
+1. Reproduce with:
+   ```bash
+   node --test --test-reporter=spec --test-timeout=15000
+   ```
+2. Isolate to one test using `--test-name-pattern`.
+3. Run with `--import why-is-node-running/include` and send `SIGUSR1`.
+4. Patch teardown where resource is created.
+5. Verify isolated 30x, then full suite.
+
+### Bad (common leak)
+
+```typescript
+it('serves requests', async () => {
+  const server = await startServer({ port: 0 });
+  const id = setInterval(() => {}, 1000);
+  // test body...
+  // ❌ no deterministic teardown
+});
+```
+
+### Good (deterministic teardown)
+
+```typescript
+import { once } from 'node:events';
+
+it('serves requests', async (t) => {
+  const server = await startServer({ port: 0 });
+  const id = setInterval(() => {}, 1000);
+
+  t.after(async () => {
+    clearInterval(id);
+    server.close();
+    await once(server, 'close');
+  });
+
+  // test body...
+});
+```
+
+## Definition of done (must all pass)
+
+- [ ] Isolated repro passes repeatedly (recommended: 30 runs) with no hangs
+- [ ] Full `node --test` run exits with code 0
+- [ ] CI completes with no timeout
+- [ ] `why-is-node-running` shows no unexpected leftover handles
+
+## Related rules
+
+- [flaky-tests.md](flaky-tests.md)
+- [testing.md](testing.md)
+- [graceful-shutdown.md](graceful-shutdown.md)


### PR DESCRIPTION
## Summary
- add `skills/node/rules/stuck-processes-and-tests.md` with a focused troubleshooting playbook
- make `why-is-node-running` the primary open-handle diagnostic recommendation
- add activation triggers, non-negotiable checklist, command path, integrated bad/good teardown example, and definition-of-done criteria
- update `skills/node/SKILL.md` with activation cues, workflow mention, and rule link

## Validation
- npm run typecheck
- npm test
