### PR TITLE
nodejs-core: require -s and merge-base format-cpp before commits

### DIFF
--- a/skills/nodejs-core/SKILL.md
+++ b/skills/nodejs-core/SKILL.md
@@ -106,23 +106,46 @@ Before starting work, **ask the user** about their build configuration
 assume a specific setup. Most of the time, `./configure` has already been
 run and only `make -j$(nproc)` is needed to rebuild.
 
-### MANDATORY: Lint before every commit
+### MANDATORY: Lint and format before every commit
 
 Node.js runs a `Linters` CI workflow on every non-draft pull request, and on
 Unix `make test` runs **no** linters. Run `make lint` before each `git
 commit` — plus `make format-cpp` for C++ changes — so the lint jobs pass on
 the first CI run instead of costing a force-push and another full cycle.
 
-```
-build  →  make lint  →  (C++: make format-cpp)  →  git commit -s
-      →  npx core-validate-commit --no-validate-metadata HEAD
+```bash
+make -j$(nproc)                                        # rebuild first
+make lint                                              # JS, C++, MD, docs, YAML
+
+# C++ changes only — use the merge-base form, which is what CI checks:
+CLANG_FORMAT_START="$(git merge-base HEAD upstream/main)" make format-cpp
+git --no-pager diff --exit-code                        # must be empty
+
+git add -A && git commit -s                            # -s is mandatory
+npx core-validate-commit --no-validate-metadata HEAD
 ```
 
-`make lint` does not cover every CI lint job: Python (`make lint-py`), shell
-(`tools/lint-sh.mjs .`), C++ formatting, and commit-message validation are
-separate jobs. See [rules/pre-commit-lint.md](rules/pre-commit-lint.md) for
-the full gate, the CI-job-to-command mapping, and the merge-base form of
-`format-cpp` that matches what CI checks.
+Never skip a step because the change looks trivial, and never commit with
+"will fix lint in a follow-up".
+
+**Bare `make format-cpp` is not enough.** It defaults to
+`CLANG_FORMAT_START=HEAD` and formats only *staged* changes, while the
+`format-cpp` CI job formats everything from the merge base and fails on any
+resulting diff — so unformatted code committed earlier in the branch passes
+locally and fails in CI. Always pass the merge-base form shown above.
+
+**Every commit must be created with `git commit -s`.** The `-s` flag adds the
+`Signed-off-by:` trailer certifying the Developer Certificate of Origin.
+Without it the `signed-off-by` rule of `core-validate-commit` fails and the PR
+cannot land. The sign-off must be the human contributor's name and email —
+never sign off with a tool or AI identity, and never fabricate someone else's.
+If you forget it, amend with `git commit --amend --signoff`.
+
+`make lint` runs `lint-js`, `lint-cpp`, `lint-addon-docs`, `lint-md`, and
+`lint-yaml` — it does not cover every CI lint job. Python (`make lint-py`),
+shell (`tools/lint-sh.mjs .`), C++ formatting, and commit-message validation
+are separate jobs. See [rules/pre-commit-lint.md](rules/pre-commit-lint.md)
+for the full gate and the CI-job-to-command mapping.
 
 Validate every commit message with `core-validate-commit`, always with
 `--no-validate-metadata` — metadata validation is on by default and enforces

--- a/skills/nodejs-core/rules/build-and-test-workflow.md
+++ b/skills/nodejs-core/rules/build-and-test-workflow.md
@@ -301,8 +301,9 @@ $EDITOR src/node_options.cc
 # 2. Rebuild (MANDATORY)
 make -j$(nproc)
 
-# 3. Format C++
-make format-cpp
+# 3. Format C++ the way CI does — from the merge base, not just staged changes
+CLANG_FORMAT_START="$(git merge-base HEAD upstream/main)" make format-cpp
+git --no-pager diff --exit-code
 
 # 4. Lint C++
 make lint-cpp
@@ -317,11 +318,7 @@ make cctest
 git add -A && git commit -s
 npx core-validate-commit --no-validate-metadata HEAD
 
-# 8. Before pushing, confirm the whole branch is formatted the way CI checks
-CLANG_FORMAT_START="$(git merge-base HEAD upstream/main)" make format-cpp
-git --no-pager diff --exit-code
-
-# 9. Run broader tests
+# 8. Run broader tests
 make test-only
 ```
 
@@ -337,7 +334,8 @@ $EDITOR doc/api/cli.md
 make -j$(nproc)
 
 # 3. Format and lint
-make format-cpp
+CLANG_FORMAT_START="$(git merge-base HEAD upstream/main)" make format-cpp
+git --no-pager diff --exit-code
 make lint
 
 # 4. Run targeted tests
@@ -389,11 +387,11 @@ substitute. See [pre-commit-lint.md](pre-commit-lint.md).
 
 ```bash
 # The CI will reject unformatted C++ code.
-# Always run after C++ changes:
+# Always run after C++ changes, before committing:
 make format-cpp-build   # first time only
-make format-cpp
 
-# And before pushing, check the whole branch the way CI does:
+# Use the merge-base form: bare `make format-cpp` only covers staged
+# changes, while CI formats the whole branch and fails on any diff.
 CLANG_FORMAT_START="$(git merge-base HEAD upstream/main)" make format-cpp
 git --no-pager diff --exit-code
 ```

--- a/skills/nodejs-core/rules/contributing.md
+++ b/skills/nodejs-core/rules/contributing.md
@@ -225,8 +225,9 @@ PR look tidy; the landing process normally handles autosquashing. A fixup
 commit can identify its target explicitly:
 
 ```bash
+make lint                              # lint gate applies to fixups too
 git add my/changed/files
-git commit --fixup <target-commit>
+git commit -s --fixup <target-commit>
 git push origin fix-issue-12345
 ```
 

--- a/skills/nodejs-core/rules/pre-commit-lint.md
+++ b/skills/nodejs-core/rules/pre-commit-lint.md
@@ -48,7 +48,17 @@ make lint-py-build && make lint-py     # only needed once for the -build step
 tools/lint-sh.mjs .                    # requires shellcheck on PATH
 ```
 
-Only commit once all of these are clean.
+Only commit once all of these are clean, and always commit with `-s`:
+
+```bash
+git add -A && git commit -s
+```
+
+**`-s` is not optional.** It adds the `Signed-off-by:` trailer that certifies
+the Developer Certificate of Origin; without it the `signed-off-by` rule fails
+in the commit-lint job and the change cannot land. It must carry the human
+contributor's name and email — never a tool or AI identity. Recover a missing
+sign-off with `git commit --amend --signoff`.
 
 Then validate the commit message you just wrote — Node.js runs a commit-lint
 CI job too:


### PR DESCRIPTION
The lint gate documented the right commands but left two ways to still get a red CI run. `git commit -s` appeared only inside examples, so the sign-off read as incidental rather than as the DCO requirement the `signed-off-by` rule enforces. And the C++ and mixed-change workflows called bare `make format-cpp`, which defaults to `CLANG_FORMAT_START=HEAD` and formats only staged changes, while the `format-cpp` CI job formats from the merge base and fails on any resulting diff.

Make the pre-commit sequence in SKILL.md runnable end to end, state that every commit is created with `-s` and why, and use the merge-base form of `format-cpp` everywhere it is invoked before a commit.


Claude-Session: https://claude.ai/code/session_01DDvbKYhM2UV9HL4ovbycX5